### PR TITLE
Update Tailwind to use v3.2

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -30,7 +30,7 @@ config :logger, :console,
 config :phoenix, :json_library, Jason
 
 config :tailwind,
-  version: "3.1.8",
+  version: "3.2.0",
   default: [
     args: ~w(
       --config=tailwind.config.js


### PR DESCRIPTION
Update the  `config.exs` file to use the latest Tailwind version (3.2)

You might need to run `mix tailwind.install` to download the latest version

ref: #188 