### PR TITLE
PR: Create migration to change `item.text` type from `string` to `text`

### DIFF
--- a/priv/repo/migrations/20221114161649_update_text_type.exs
+++ b/priv/repo/migrations/20221114161649_update_text_type.exs
@@ -1,0 +1,9 @@
+defmodule App.Repo.Migrations.UpdateTextType do
+  use Ecto.Migration
+
+  def change do
+    alter table(:items) do
+      modify :text, :text
+    end
+  end
+end

--- a/test/app/item_test.exs
+++ b/test/app/item_test.exs
@@ -23,6 +23,24 @@ defmodule App.ItemTest do
       assert inserted_item.text == @valid_attrs.text
     end
 
+    test "create_item/1 with long text" do
+      attrs = %{
+        text: "This is a long text, This is a long text,
+                This is a long text,This is a long text,This is a long text,
+                This is a long text,This is a long text,This is a long text,
+                This is a long text,This is a long text,This is a long text,
+                This is a long text,This is a long text,This is a long text,
+                This is a long text,This is a long text,This is a long text,
+            ",
+        person_id: 1,
+        status: 2
+      }
+
+      assert {:ok, %Item{} = item} = Item.create_item(attrs)
+
+      assert item.text == attrs.text
+    end
+
     test "create_item/1 with invalid data returns error changeset" do
       assert {:error, %Ecto.Changeset{}} = Item.create_item(@invalid_attrs)
     end


### PR DESCRIPTION
Update type for item's text
ref: #204