### PR TITLE
Display long tag name with ellipsis

### DIFF
--- a/lib/app_web/templates/tag/index.html.heex
+++ b/lib/app_web/templates/tag/index.html.heex
@@ -13,7 +13,8 @@
         <.td>
           <span
             style={"background-color:#{tag.color}"}
-            class="text-white font-bold py-1 px-2 rounded-full"
+            class="w-40 text-white font-bold py-1 px-2 rounded-full 
+            overflow-hidden text-ellipsis whitespace-nowrap inline-block"
           >
             <%= tag.text %>
           </span>


### PR DESCRIPTION
Add css classes to add ellipsis when tag name is too long to be displayed in the table

see: #217