### PR TITLE
Add "create tag" in select input

### DIFF
--- a/lib/app_web/live/app_live.html.heex
+++ b/lib/app_web/live/app_live.html.heex
@@ -85,6 +85,11 @@
               </div>
             </li>
           <% end %>
+          <%= if Enum.empty?(@tags) and String.length(String.trim(@search_tag)) != 0 do %>
+          <li class="border-b p-2 cursor-pointer hover:bg-slate-200" phx-click="create-tag" phx-value-tag={@search_tag}>
+            <span class="block w-full text-center overflow-hidden text-ellipsis whitespace-nowrap"><%= "Create #{@search_tag}" %></span>
+          </li>
+          <% end %>
           <li class="border-b p-2 cursor-pointer hover:bg-slate-200">
             <%= link("edit tags", to: "/tags", class: "block w-full text-center") %>
           </li>

--- a/lib/app_web/live/app_live.html.heex
+++ b/lib/app_web/live/app_live.html.heex
@@ -86,9 +86,15 @@
             </li>
           <% end %>
           <%= if Enum.empty?(@tags) and String.length(String.trim(@search_tag)) != 0 do %>
-          <li class="border-b p-2 cursor-pointer hover:bg-slate-200" phx-click="create-tag" phx-value-tag={@search_tag}>
-            <span class="block w-full text-center overflow-hidden text-ellipsis whitespace-nowrap"><%= "Create #{@search_tag}" %></span>
-          </li>
+            <li
+              class="border-b p-2 cursor-pointer hover:bg-slate-200"
+              phx-click="create-tag"
+              phx-value-tag={@search_tag}
+            >
+              <span class="block w-full text-center overflow-hidden text-ellipsis whitespace-nowrap">
+                <%= "Create #{@search_tag}" %>
+              </span>
+            </li>
           <% end %>
           <li class="border-b p-2 cursor-pointer hover:bg-slate-200">
             <%= link("edit tags", to: "/tags", class: "block w-full text-center") %>

--- a/test/app_web/live/app_live_test.exs
+++ b/test/app_web/live/app_live_test.exs
@@ -697,6 +697,11 @@ defmodule AppWeb.AppLiveTest do
     {:ok, view, _html} = live(conn, "/")
     assert render_hook(view, "filter-tags", %{"key" => "t", "value" => "t"})
   end
+  
+  test "create tag from select input", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+    assert render_hook(view, "create-tag", %{"tag" => "new tag"})
+  end
 
   defp create_person(_) do
     person = Person.create_person(%{"person_id" => 0, "name" => "guest"})

--- a/test/app_web/live/app_live_test.exs
+++ b/test/app_web/live/app_live_test.exs
@@ -697,7 +697,7 @@ defmodule AppWeb.AppLiveTest do
     {:ok, view, _html} = live(conn, "/")
     assert render_hook(view, "filter-tags", %{"key" => "t", "value" => "t"})
   end
-  
+
   test "create tag from select input", %{conn: conn} do
     {:ok, view, _html} = live(conn, "/")
     assert render_hook(view, "create-tag", %{"tag" => "new tag"})


### PR DESCRIPTION
Please feel free to discard/close this PR, see https://github.com/dwyl/mvp/issues/221#issuecomment-1332004568

It is in example how a tag can be created from the select input.
As mentioned in the issue, this is not a prefect UX, this PR can be used for testing and discussion.