### PR TITLE
PR: DRY Assign JWT to Socket Code issue #215

### DIFF
--- a/BUILDIT.md
+++ b/BUILDIT.md
@@ -1290,18 +1290,7 @@ defmodule AppWeb.AuthController do
   import Phoenix.LiveView, only: [assign_new: 3]
 
   def on_mount(:default, _params, %{"jwt" => jwt} = _session, socket) do
-
-    claims = jwt
-    |> AuthPlug.Token.verify_jwt!()
-    |> AuthPlug.Helpers.strip_struct_metadata()
-    |> Useful.atomize_map_keys()
-
-    socket =
-      socket
-      |> assign_new(:person, fn -> claims end)
-      |> assign_new(:loggedin, fn -> true end)
-
-    {:cont, socket}
+    {:cont, AuthPlug.assign_jwt_to_socket(socket, &Phoenix.Component.assign_new/3, jwt)}
   end
 
   def on_mount(:default, _params, _session, socket) do

--- a/lib/app_web/controllers/auth_controller.ex
+++ b/lib/app_web/controllers/auth_controller.ex
@@ -3,8 +3,18 @@ defmodule AppWeb.AuthController do
   import Phoenix.Component, only: [assign_new: 3]
 
   def on_mount(:default, _params, %{"jwt" => jwt} = _session, socket) do
-    {:cont,
-     AuthPlug.assign_jwt_to_socket(socket, &Phoenix.Component.assign_new/3, jwt)}
+    claims =
+      jwt
+      |> AuthPlug.Token.verify_jwt!()
+      |> AuthPlug.Helpers.strip_struct_metadata()
+      |> Useful.atomize_map_keys()
+
+    socket =
+      socket
+      |> assign_new(:person, fn -> claims end)
+      |> assign_new(:loggedin, fn -> true end)
+
+    {:cont, socket}
   end
 
   def on_mount(:default, _params, _session, socket) do

--- a/lib/app_web/controllers/auth_controller.ex
+++ b/lib/app_web/controllers/auth_controller.ex
@@ -3,18 +3,7 @@ defmodule AppWeb.AuthController do
   import Phoenix.Component, only: [assign_new: 3]
 
   def on_mount(:default, _params, %{"jwt" => jwt} = _session, socket) do
-    claims =
-      jwt
-      |> AuthPlug.Token.verify_jwt!()
-      |> AuthPlug.Helpers.strip_struct_metadata()
-      |> Useful.atomize_map_keys()
-
-    socket =
-      socket
-      |> assign_new(:person, fn -> claims end)
-      |> assign_new(:loggedin, fn -> true end)
-
-    {:cont, socket}
+    {:cont, AuthPlug.assign_jwt_to_socket(socket, &Phoenix.Component.assign_new/3, jwt)}
   end
 
   def on_mount(:default, _params, _session, socket) do

--- a/lib/app_web/controllers/auth_controller.ex
+++ b/lib/app_web/controllers/auth_controller.ex
@@ -3,7 +3,8 @@ defmodule AppWeb.AuthController do
   import Phoenix.Component, only: [assign_new: 3]
 
   def on_mount(:default, _params, %{"jwt" => jwt} = _session, socket) do
-    {:cont, AuthPlug.assign_jwt_to_socket(socket, &Phoenix.Component.assign_new/3, jwt)}
+    {:cont,
+     AuthPlug.assign_jwt_to_socket(socket, &Phoenix.Component.assign_new/3, jwt)}
   end
 
   def on_mount(:default, _params, _session, socket) do

--- a/lib/app_web/controllers/auth_controller.ex
+++ b/lib/app_web/controllers/auth_controller.ex
@@ -1,7 +1,6 @@
 defmodule AppWeb.AuthController do
   use AppWeb, :controller
 
-  import AuthPlug, only: [assign_jwt_to_socket: 3]
   import Phoenix.Component, only: [assign_new: 3]
 
   def on_mount(:default, _params, %{"jwt" => jwt} = _session, socket) do

--- a/lib/app_web/controllers/auth_controller.ex
+++ b/lib/app_web/controllers/auth_controller.ex
@@ -1,20 +1,12 @@
 defmodule AppWeb.AuthController do
   use AppWeb, :controller
+
+  import AuthPlug, only: [assign_jwt_to_socket: 3]
   import Phoenix.Component, only: [assign_new: 3]
 
   def on_mount(:default, _params, %{"jwt" => jwt} = _session, socket) do
-    claims =
-      jwt
-      |> AuthPlug.Token.verify_jwt!()
-      |> AuthPlug.Helpers.strip_struct_metadata()
-      |> Useful.atomize_map_keys()
-
-    socket =
-      socket
-      |> assign_new(:person, fn -> claims end)
-      |> assign_new(:loggedin, fn -> true end)
-
-    {:cont, socket}
+    {:cont,
+     AuthPlug.assign_jwt_to_socket(socket, &Phoenix.Component.assign_new/3, jwt)}
   end
 
   def on_mount(:default, _params, _session, socket) do


### PR DESCRIPTION
This PR adds in application of `auth_plug`. Both the documentation within `BUILDIT` and `auth_controller` itself have been updated.

Question:
@nelsonic I saw you stated both instructions needed to be updated in the BUILDIT, but I didn't see where else this function was used. Were you referring to the second `on_mount` function at [auth_controller](https://github.com/dwyl/mvp/blob/78c06aea16d1436f08af3ac7da6578a70423ff38/lib/app_web/controllers/auth_controller.ex#L20)? If so, I didn't know if I needed to add the pattern matching for the `jwt` there as well. 

I think there's several blockers on this one. We've got two failing tests related to this change.

1. We're using `auth_plug` 1.4.14 in our `mix.exs` at [https://github.com/dwyl/mvp/blob/78c06aea16d1436f08af3ac7da6578a70423ff38/mix.exs#L63](auth_plug). This does not include the new `assign_jwt_to_socket/3` function. We'll need to update to 1.5.1 to get access to it.
2. Updating `auth_plug` to 1.5.1 results in a dependency loop: 
![image](https://user-images.githubusercontent.com/36017878/205227779-6d54c2c5-4eae-4e2f-9b95-54851b29e7cc.png)
updating `envar`
![image](https://user-images.githubusercontent.com/36017878/205227891-1f2e7ab7-5621-4d03-965f-5d1ecac6f5b3.png)

Can those be updated at this time? I didn't go further than the `fields` dependency.

