### PR TITLE
Parse tags regex

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -20,7 +20,7 @@ config :app, AppWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
   http: [ip: {127, 0, 0, 1}, port: 4000],
-  check_origin: false,
+  check_origin: ["https://*.fly.dev", "http://localhost:4000/"],
   code_reloader: true,
   debug_errors: true,
   secret_key_base:

--- a/lib/app/item.ex
+++ b/lib/app/item.ex
@@ -26,7 +26,7 @@ defmodule App.Item do
 
   def changeset_with_tags(item, attrs) do
     changeset(item, attrs)
-    |> put_assoc(:tags, attrs.tags)
+    |> put_assoc(:tags, Tag.create_tags(attrs.tags, attrs.person_id))
   end
 
   @doc """

--- a/lib/app_web/live/app_live.ex
+++ b/lib/app_web/live/app_live.ex
@@ -36,18 +36,27 @@ defmodule AppWeb.AppLive do
 
   @impl true
   def handle_event("validate", %{"text" => text}, socket) do
-    {:noreply, assign(socket, text_value: text)}
+    tags =
+      Regex.scan(~r/#(\w+)/, text)
+      |> Enum.map(fn t ->
+        tag = Enum.at(t, 1)
+        %Tag{text: tag, color: "#FCA5A5"}
+      end)
+      |> Enum.uniq_by(fn tag -> String.downcase(tag.text) end)
+
+    {:noreply, assign(socket, text_value: text, selected_tags: tags)}
   end
 
   @impl true
   def handle_event("create", %{"text" => text}, socket) do
     person_id = get_person_id(socket.assigns)
+    selected_tags_text = Enum.map(socket.assigns.selected_tags, & &1.text)
 
     Item.create_item_with_tags(%{
       text: text,
       person_id: person_id,
       status: 2,
-      tags: socket.assigns.selected_tags
+      tags: selected_tags_text
     })
 
     AppWeb.Endpoint.broadcast(@topic, "update", :create)

--- a/lib/app_web/live/app_live.html.heex
+++ b/lib/app_web/live/app_live.html.heex
@@ -17,7 +17,7 @@
       name="text"
       phx-change="validate"
       phx-debounce="500"
-      placeholder="What needs to be done?!!!"
+      placeholder="What needs to be done?"
       autofocus="true"
       required="required"
       x-data="{resize() {

--- a/lib/app_web/live/app_live.html.heex
+++ b/lib/app_web/live/app_live.html.heex
@@ -17,7 +17,7 @@
       name="text"
       phx-change="validate"
       phx-debounce="500"
-      placeholder="What needs to be done?"
+      placeholder="What needs to be done?!"
       autofocus="true"
       required="required"
       x-data="{resize() {

--- a/lib/app_web/live/app_live.html.heex
+++ b/lib/app_web/live/app_live.html.heex
@@ -16,6 +16,7 @@
         my-2"
       name="text"
       phx-change="validate"
+      phx-debounce="500"
       placeholder="What needs to be done?!!!"
       autofocus="true"
       required="required"
@@ -27,77 +28,11 @@
       x-init="resize"
       x-on:input="resize"
     ><%= @text_value %></textarea>
-    <!-- Select Input -->
-    <div
-      class="lg:w-1/2 "
-      x-data="{open: false}"
-      x-on:click.away="open = false"
-      x-on:keydown.escape="open = false"
-    >
-      <input
-        type="text"
-        name="tag"
-        class="w-full my-2"
-        x-on:focus="open = true"
-        phx-keyup="filter-tags"
-        phx-debounce="250"
-        autocomplete="off"
-        placeholder="tags"
-      />
-      <div
-        class="relative z-10 drop-shadow-lg w-auto"
-        x-show="open"
-        x-transition
-        x-cloak
-      >
-        <ul class="absolute border bg-white max-h-64 overflow-auto w-full">
-          <%= for tag <- @tags do %>
-            <li
-              class="border-b p-2 cursor-pointer hover:bg-slate-200"
-              phx-click="toggle_tag"
-              phx-value-tag_id={tag.id}
-            >
-              <div class="relative h-10">
-                <div class="inline-flex items-center w-3/4">
-                  <span
-                    class="w-5 h-5 bg-red-500 rounded-full mx-2 shrink-0"
-                    style={"background-color:#{tag.color}"}
-                  >
-                  </span>
-                  <span class="overflow-hidden text-ellipsis whitespace-nowrap">
-                    <%= tag.text %>
-                  </span>
-                </div>
-                <%= if Enum.member?(@selected_tags, tag) do %>
-                  <svg
-                    class="absolute font-bold w-4 top-0 bottom-0 m-auto right-0 text-green-500"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                  >
-                    <path
-                      fill-rule="evenodd"
-                      d="M19.916 4.626a.75.75 0 01.208 1.04l-9 13.5a.75.75 0 01-1.154.114l-6-6a.75.75 0 011.06-1.06l5.353 5.353 8.493-12.739a.75.75 0 011.04-.208z"
-                      clip-rule="evenodd"
-                    />
-                  </svg>
-                <% end %>
-              </div>
-            </li>
-          <% end %>
-          <li class="border-b p-2 cursor-pointer hover:bg-slate-200">
-            <%= link("edit tags", to: "/tags", class: "block w-full text-center") %>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <!-- End Select Input -->
-
     <!-- Display the selected tags -->
     <div class="">
       <%= for selected_tag <- @selected_tags do %>
         <span
-          class="text-white font-bold py-1 px-2 rounded-full ml-2"
+          class="text-white font-bold py-1 px-2 rounded-full ml-2 mt-2"
           style={"background-color:#{selected_tag.color}"}
         >
           <%= selected_tag.text %>

--- a/test/app_web/live/app_live_test.exs
+++ b/test/app_web/live/app_live_test.exs
@@ -583,7 +583,7 @@ defmodule AppWeb.AppLiveTest do
         text: "Item1 to do",
         person_id: 0,
         status: 2,
-        tags: [tag1, tag2]
+        tags: [tag1.text, tag2.text]
       })
 
     {:ok, _item} =
@@ -591,7 +591,7 @@ defmodule AppWeb.AppLiveTest do
         text: "Item2 to do",
         person_id: 0,
         status: 2,
-        tags: [tag1, tag3]
+        tags: [tag1.text, tag3.text]
       })
 
     {:ok, view, _html} = live(conn, "/?filter_by=all")


### PR DESCRIPTION
Test it at: https://mvp-pr-234.fly.dev/ ~(database unavailable at the moment, looking into it, similar error to https://github.com/dwyl/hits/issues/203)~ fixed with #235 
![image](https://user-images.githubusercontent.com/6057298/207607681-a53138b4-f779-499c-b9e8-4ab230f8edf4.png)

Parse tags using regex. The regex search for tag name starting with `#`.
The selected tags are displayed under the textarea with a default colour.
When the item is created the tags are saved if new ones are created

@nelsonic @iteles Would this be a better solution than #222 (dropdown tags)?
If yes, I can continue to improve this PR:
- Remove the tag text from the item text once the item is created (ie delete #<tag-name>)
- Apply the same feature when editing an item