### PR TITLE
Do not create review app for dependabot PRs

### DIFF
--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -6,6 +6,7 @@ env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 jobs:
   review_app:
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     name: Review App Job
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add condition to check author PR name and only run the Github action if the author is not dependabot

see: #259 