### PR TITLE
Update content-policy

### DIFF
--- a/lib/app_web/templates/layout/icons.html.heex
+++ b/lib/app_web/templates/layout/icons.html.heex
@@ -3,11 +3,11 @@
 <meta
   http-equiv="Content-Security-Policy"
   content="
-        default-src 'self' dwyl.com https://*.cloudflare.com; 
-        connect-src 'self' wss://mvp.fly.dev;
+        default-src 'self' dwyl.com https://*.cloudflare.com plausible.io; 
+        connect-src 'self' wss://mvp.fly.dev plausible.io;
         form-action 'self';
         img-src *; child-src 'none';
-        script-src 'self' https://cdnjs.cloudflare.com 'unsafe-eval' 'unsafe-inline';
+        script-src 'self' https://cdnjs.cloudflare.com plausible.io 'unsafe-eval' 'unsafe-inline';
         style-src 'self' 'unsafe-inline';
       "
 />

--- a/lib/app_web/templates/layout/root.html.heex
+++ b/lib/app_web/templates/layout/root.html.heex
@@ -4,7 +4,7 @@
     <meta name="csrf-token" content={csrf_token_value()} />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src plausible.io; connect-src plausible.io"
+      content="default-src 'self'; script-src 'self' https://plausible.io https://cdnjs.cloudflare.com; connect-src 'self' https://plausible.io; img-src 'self' https://dwyl.com"
     />
 
     <.live_title prefix="dwyl – ">

--- a/lib/app_web/templates/layout/root.html.heex
+++ b/lib/app_web/templates/layout/root.html.heex
@@ -2,10 +2,6 @@
 <html lang="en">
   <head>
     <meta name="csrf-token" content={csrf_token_value()} />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' https://plausible.io https://cdnjs.cloudflare.com; connect-src 'self' https://plausible.io; img-src 'self' https://dwyl.com"
-    />
 
     <.live_title prefix="dwyl – ">
       <%= assigns[:page_title] || "mvp" %>


### PR DESCRIPTION
Allow 'self' plus plausible and cloudflare.

After a few tries, I found that we have already a content policy defined in `layout/templates/icons.html.heex` file (not sure why)
That's why the content policy in the root.html template didn't work as there was a conflict with the existing one.

I've updated the icons template to add plausible.io and deployed it manually to test. It worked:
![image](https://user-images.githubusercontent.com/6057298/217070366-443902bc-d5aa-496e-b683-204996a58f0d.png)


I've noticed from the content policy that we are using `dwyl.com` to get images (logo, icons). I think we could copy these images directly on the mvp project as assets. We won't have to send request to the dwyl.com domain and maybe speed up the requests.