### PR TITLE
PR: move selected `tags` above `tags` selector #296

### DIFF
--- a/lib/api/localhost.json
+++ b/lib/api/localhost.json
@@ -5,8 +5,5 @@
   "invalid_id": "invalid_id",
   "timer_id": "1",
   "notfound_timer_id": "-1",
-  "timer_id_to_stop": 2,
-  "tag_id": 1,
-  "notfound_tag_id": -1,
-  "item_id_with_tag": 1
+  "timer_id_to_stop": 2
 }

--- a/lib/app_web/live/app_live.html.heex
+++ b/lib/app_web/live/app_live.html.heex
@@ -32,6 +32,17 @@
       resize"
       x-on:input="resize"
     ><%= @text_value %></textarea>
+    <!-- Display the selected tags -->
+    <div class="">
+      <%= for selected_tag <- @selected_tags do %>
+        <span
+          class="text-white font-bold py-1 px-2 rounded-full ml-2"
+          style={"background-color:#{selected_tag.color}"}
+        >
+          <%= selected_tag.text %>
+        </span>
+      <% end %>
+    </div>
     <!-- Select Input -->
     <div
       class="lg:w-1/2 "
@@ -97,18 +108,6 @@
       </div>
     </div>
     <!-- End Select Input -->
-
-    <!-- Display the selected tags -->
-    <div class="">
-      <%= for selected_tag <- @selected_tags do %>
-        <span
-          class="text-white font-bold py-1 px-2 rounded-full ml-2"
-          style={"background-color:#{selected_tag.color}"}
-        >
-          <%= selected_tag.text %>
-        </span>
-      <% end %>
-    </div>
     <!-- Want to help "DRY" this? see: https://github.com/dwyl/app-mvp-phoenix/issues/105 -->
     <!-- https://tailwindcss.com/docs/justify-content#end -->
     <div class="flex justify-end mr-1">


### PR DESCRIPTION
+ [x] Fixes the bug noted in #296 where the tag selector covers the selected tags. 