### PR TITLE
Call resize() on x:init

### DIFF
--- a/lib/app_web/live/app_live.html.heex
+++ b/lib/app_web/live/app_live.html.heex
@@ -29,7 +29,7 @@
       x-init="$el.selectionStart= $el.value.length;
       $el.selectionEnd= $el.value.length;
       $el.focus();
-      resize"
+      resize();"
       x-on:input="resize"
     ><%= @text_value %></textarea>
     <!-- Display the selected tags -->


### PR DESCRIPTION
Make sure the textarea is properly resized
when the text draft is saved

see: #305