### PR TITLE
Add Tag on task using Enter

### DIFF
--- a/lib/app_web/live/app_live.ex
+++ b/lib/app_web/live/app_live.ex
@@ -36,7 +36,8 @@ defmodule AppWeb.AppLive do
        text_value: draft_item.text || "",
 
        # Offset from the client to UTC. If it's "1", it means we are one hour ahead of UTC.
-       hours_offset_fromUTC: get_connect_params(socket)["hours_offset_fromUTC"] || 0
+       hours_offset_fromUTC:
+         get_connect_params(socket)["hours_offset_fromUTC"] || 0
      )}
   end
 
@@ -197,7 +198,8 @@ defmodule AppWeb.AppLive do
 
     timers_list_changeset = Timer.list_timers_changesets(item_id)
 
-    {:noreply, assign(socket, editing: item_id, editing_timers: timers_list_changeset)}
+    {:noreply,
+     assign(socket, editing: item_id, editing_timers: timers_list_changeset)}
   end
 
   @impl true

--- a/lib/app_web/live/app_live.ex
+++ b/lib/app_web/live/app_live.ex
@@ -119,7 +119,7 @@ defmodule AppWeb.AppLive do
   @impl true
   def handle_event(
         "add-first-tag",
-        %{"key" => "Enter", "value" => _value},
+        %{"key" => "Enter"},
         socket
       ) do
     case socket.assigns.tags do

--- a/lib/app_web/live/app_live.ex
+++ b/lib/app_web/live/app_live.ex
@@ -103,15 +103,6 @@ defmodule AppWeb.AppLive do
     {:noreply, assign(socket, tags: tags, selected_tags: selected_tags)}
   end
 
-  defp toggle_tag(selected_tags, tag) do
-    if Enum.member?(selected_tags, tag) do
-      List.delete(selected_tags, tag)
-    else
-      [tag | selected_tags]
-    end
-    |> Enum.sort_by(& &1.text)
-  end
-
   @impl true
   def handle_event("filter-tags", %{"key" => _key, "value" => value}, socket) do
     person_id = get_person_id(socket.assigns)
@@ -413,6 +404,15 @@ defmodule AppWeb.AppLive do
     else
       items
     end
+  end
+
+  defp toggle_tag(selected_tags, tag) do
+    if Enum.member?(selected_tags, tag) do
+      List.delete(selected_tags, tag)
+    else
+      [tag | selected_tags]
+    end
+    |> Enum.sort_by(& &1.text)
   end
 
   def class_footer_link(filter_name, filter_selected) do

--- a/lib/app_web/live/app_live.ex
+++ b/lib/app_web/live/app_live.ex
@@ -130,16 +130,22 @@ defmodule AppWeb.AppLive do
         %{"key" => "Enter", "value" => _value},
         socket
       ) do
-    selected_tag =
-      socket.assigns.tags
-      |> List.first()
-      |> Map.get(:id)
-      |> Tag.get_tag!()
+    case socket.assigns.tags do
+      [] ->
+        {:noreply, socket}
 
-    {:noreply,
-     assign(socket,
-       selected_tags: toggle_tag(socket.assigns.selected_tags, selected_tag)
-     )}
+      _ ->
+        selected_tag =
+          socket.assigns.tags
+          |> List.first()
+          |> Map.get(:id)
+          |> Tag.get_tag!()
+
+        {:noreply,
+         assign(socket,
+           selected_tags: toggle_tag(socket.assigns.selected_tags, selected_tag)
+         )}
+    end
   end
 
   @impl true

--- a/lib/app_web/live/app_live.html.heex
+++ b/lib/app_web/live/app_live.html.heex
@@ -56,8 +56,10 @@
         name="tag"
         class="w-full my-2"
         x-on:focus="open = true"
+        x-on:keydown.enter.prevent=""
         phx-keyup="filter-tags"
-        phx-debounce="250"
+        phx-keyup-debounce="250"
+        phx-keydown="add-first-tag"
         autocomplete="off"
         placeholder="tags"
       />

--- a/lib/app_web/live/app_live.html.heex
+++ b/lib/app_web/live/app_live.html.heex
@@ -56,7 +56,11 @@
         name="tag"
         class="w-full my-2"
         x-on:focus="open = true"
-        x-on:keydown.enter.prevent=""
+        x-on:keydown.enter.prevent="
+          if (event.key === 'Enter') {
+            event.target.value = '';
+          }
+        "
         phx-keyup="filter-tags"
         phx-keyup-debounce="250"
         phx-keydown="add-first-tag"

--- a/test/app_web/live/app_live_test.exs
+++ b/test/app_web/live/app_live_test.exs
@@ -806,4 +806,37 @@ defmodule AppWeb.AppLiveTest do
     {:ok, view, _html} = live(conn, "/")
     assert render_hook(view, "filter-tags", %{"key" => "t", "value" => "t"})
   end
+
+  test "select tag when enter pressed", %{conn: conn} do
+    {:ok, _tag1} =
+      Tag.create_tag(%{person_id: 0, text: "tag1", color: "#FCA5A5"})
+
+    {:ok, _tag2} =
+      Tag.create_tag(%{
+        person_id: 0,
+        text: "enter_tag_selected",
+        color: "#FCA5A5"
+      })
+
+    {:ok, view, _html} = live(conn, "/")
+
+    assert render_keydown(view, "add-first-tag", %{"key" => "Enter"})
+
+    assert render_submit(view, :create, %{text: "tag enter pressed"})
+
+    assert render(view) =~ "tag enter pressed"
+    assert render(view) =~ "enter_tag_selected"
+  end
+
+  test "dont select tag if there arent tags created", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+
+    assert render_keydown(view, "add-first-tag", %{"key" => "Enter"})
+
+    assert render_submit(view, :create, %{text: "tag enter pressed"})
+
+    last_item_inserted = Item.list_person_items(0) |> List.last()
+
+    assert last_item_inserted.tags == []
+  end
 end

--- a/test/app_web/live/app_live_test.exs
+++ b/test/app_web/live/app_live_test.exs
@@ -820,7 +820,8 @@ defmodule AppWeb.AppLiveTest do
 
     {:ok, view, _html} = live(conn, "/")
 
-    assert render_keydown(view, "add-first-tag", %{"key" => "Enter"})
+    assert render_keydown(view, "add-first-tag", %{"key" => "Enter"}) =~
+             "enter_tag_selected"
 
     assert render_submit(view, :create, %{text: "tag enter pressed"})
 
@@ -832,6 +833,18 @@ defmodule AppWeb.AppLiveTest do
     {:ok, view, _html} = live(conn, "/")
 
     assert render_keydown(view, "add-first-tag", %{"key" => "Enter"})
+
+    assert render_submit(view, :create, %{text: "tag enter pressed"})
+
+    last_item_inserted = Item.list_person_items(0) |> List.last()
+
+    assert last_item_inserted.tags == []
+  end
+
+  test "dont select tag if other keydown is pressed", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/")
+
+    assert render_keydown(view, "add-first-tag", %{"key" => "Esc"})
 
     assert render_submit(view, :create, %{text: "tag enter pressed"})
 

--- a/test/app_web/live/app_live_test.exs
+++ b/test/app_web/live/app_live_test.exs
@@ -811,12 +811,13 @@ defmodule AppWeb.AppLiveTest do
     {:ok, _tag1} =
       Tag.create_tag(%{person_id: 0, text: "tag1", color: "#FCA5A5"})
 
-    {:ok, _tag2} =
-      Tag.create_tag(%{
-        person_id: 0,
-        text: "enter_tag_selected",
-        color: "#FCA5A5"
-      })
+    used_tag = %{
+      person_id: 0,
+      text: "enter_tag_selected",
+      color: "#FCA5A5"
+    }
+
+    {:ok, _tag2} = Tag.create_tag(used_tag)
 
     {:ok, view, _html} = live(conn, "/")
 
@@ -827,6 +828,14 @@ defmodule AppWeb.AppLiveTest do
 
     assert render(view) =~ "tag enter pressed"
     assert render(view) =~ "enter_tag_selected"
+
+    last_item_inserted = Item.list_person_items(0) |> List.last()
+
+    [tag | _] = last_item_inserted.tags
+
+    assert tag.person_id == used_tag.person_id
+    assert tag.text == used_tag.text
+    assert tag.color == used_tag.color
   end
 
   test "dont select tag if there arent tags created", %{conn: conn} do


### PR DESCRIPTION
This PR adds the functionality to select Tags when the user presses Enter while searching for tags.

It will always pick the first tag that appears on the list, if there are no tags, nothing will be added.

The behavior is detailed on [the issue](https://github.com/dwyl/mvp/issues/308).

I tried to make it simple.

Please, let me know if you guys think it's needed any changes.

I didn't like the way I managed to empty the field after the user press Enter but I tried using LiveView <.input> with no success, if you guys have any other ideas let me know, I'd love to learn since I'm new to Phoenix/LiveView.

:D
