### PR TITLE
Tags Page with more details

### DIFF
--- a/BUILDIT.md
+++ b/BUILDIT.md
@@ -113,16 +113,22 @@ With that in place, let's get building!
   - [14.3 Building the Stats Page](#143-building-the-stats-page)
   - [14.4 Broadcasting to `stats` channel](#144-broadcasting-to-stats-channel)
   - [14.5 Adding tests](#145-adding-tests)
-- [15. `People` in Different Timezones 🌐](#15-people-in-different-timezones-)
-  - [15.1 Getting the `person`'s Timezone](#151-getting-the-persons-timezone)
-  - [15.2 Changing how the timer datetime is displayed](#152-changing-how-the-timer-datetime-is-displayed)
-  - [15.3 Persisting the adjusted timezone](#153-persisting-the-adjusted-timezone)
-  - [15.4 Adding test](#154-adding-test)
-- [16. `Lists`](#16-lists)
-- [17. Reordering `items` Using Drag \& Drop](#17-reordering-items-using-drag--drop)
-- [18. Run the _Finished_ MVP App!](#18-run-the-finished-mvp-app)
-  - [18.1 Run the Tests](#181-run-the-tests)
-  - [18.2 Run The App](#182-run-the-app)
+- [15. Implementing Enhanced Tag Details and Sorting](#15-implementing-enhanced-tag-details-and-sorting)
+  - [Implementing the `toggle_sort_order` in `Repo.ex`](#implementing-the-toggle_sort_order-in-repoex)
+  - [Extending the `Tag` Model](#extending-the-tag-model)
+  - [Adding the new columns on the `Tags` Page](#adding-the-new-columns-on-the-tags-page)
+    - [Creating the LiveView HTML template](#creating-the-liveview-html-template)
+  - [Adding the new page to the router](#adding-the-new-page-to-the-router)
+- [16. `People` in Different Timezones 🌐](#16-people-in-different-timezones-)
+  - [16.1 Getting the `person`'s Timezone](#161-getting-the-persons-timezone)
+  - [16.2 Changing how the timer datetime is displayed](#162-changing-how-the-timer-datetime-is-displayed)
+  - [16.3 Persisting the adjusted timezone](#163-persisting-the-adjusted-timezone)
+  - [16.4 Adding test](#164-adding-test)
+- [17. `Lists`](#17-lists)
+- [18. Reordering `items` Using Drag \& Drop](#18-reordering-items-using-drag--drop)
+- [19. Run the _Finished_ MVP App!](#19-run-the-finished-mvp-app)
+  - [19.1 Run the Tests](#191-run-the-tests)
+  - [19.2 Run The App](#192-run-the-app)
 - [Thanks!](#thanks)
 
 
@@ -5396,8 +5402,580 @@ when creating `timers` or `items`.
 
 ![stats_final](https://user-images.githubusercontent.com/17494745/211345854-c541d21c-4289-4576-8fcf-c3b89251ed02.gif)
 
+# 15. Implementing Enhanced Tag Details and Sorting
 
-# 15. `People` in Different Timezones 🌐
+These modifications are designed to enhance functionality and improve user experience. 
+We'll cover updates made to the `Repo` module, changes in the `Tag` schema, 
+alterations in the `TagController` and `StatsLive` modules, 
+and updates to LiveView files.
+
+## Implementing the `toggle_sort_order` in `Repo.ex`
+
+The `toggle_sort_order` function in the `Repo` module allows us to dynamically change the sorting order of our database queries. 
+This is useful for features where the user can sort items in ascending or descending order that will be used throughout the whole app where we need to sort it.
+
+`lib/app/repo.ex`
+```elixir
+def toggle_sort_order(:asc), do: :desc
+def toggle_sort_order(:desc), do: :asc
+```
+If the current order is :asc (ascending), it changes to :desc (descending), and vice versa​​.
+
+## Extending the `Tag` Model
+
+Open `lib/app/tag.ex` and add new fields to the `Tag` schema.
+
+```elixir
+field :last_used_at, :naive_datetime, virtual: true
+field :items_count, :integer, virtual: true
+field :total_time_logged, :integer, virtual: true
+```
+These fields are 'virtual', meaning they're not stored in the database but calculated on the fly.
+
+The purposes of the fields are:
+`last_used_at`: the date a Tag was last used
+`items_count`: how many items are using the Tag
+`total_time_logged`: the total time that was logged with this particular Tag being used by a Item
+
+We will add a new method that will query with these new fields on the same file. 
+
+Define `list_person_tags_complete/3`:
+
+```elixir
+def list_person_tags_complete(
+      person_id,
+      sort_column \\ :text,
+      sort_order \\ :asc
+    ) do
+  sort_column =
+    if validate_sort_column(sort_column), do: sort_column, else: :text
+
+  Tag
+  |> where(person_id: ^person_id)
+  |> join(:left, [t], it in ItemTag, on: t.id == it.tag_id)
+  |> join(:left, [t, it], i in Item, on: i.id == it.item_id)
+  |> join(:left, [t, it, i], tm in Timer, on: tm.item_id == i.id)
+  |> group_by([t], t.id)
+  |> select([t, it, i, tm], %{
+    t
+    | last_used_at: max(it.inserted_at),
+      items_count: fragment("count(DISTINCT ?)", i.id),
+      total_time_logged:
+        sum(
+          coalesce(
+            fragment(
+              "EXTRACT(EPOCH FROM (? - ?))",
+              tm.stop,
+              tm.start
+            ),
+            0
+          )
+        )
+  })
+  |> order_by(^get_order_by_keyword(sort_column, sort_order))
+  |> Repo.all()
+end
+```
+
+And add these new methods at the end of the file:
+
+```elixir
+defp validate_sort_column(column) do
+  Enum.member?(
+    [
+      :text,
+      :color,
+      :created_at,
+      :last_used_at,
+      :items_count,
+      :total_time_logged
+    ],
+    column
+  )
+end
+
+defp get_order_by_keyword(sort_column, :asc) do
+  [asc: sort_column]
+end
+
+defp get_order_by_keyword(sort_column, :desc) do
+  [desc: sort_column]
+end
+```
+
+These methods are used in the previous method to validate the columns 
+that can be searched and to transform into keywords [asc: column] to work on the query.
+
+## Adding the new columns on the `Tags` Page
+
+First, we need to remove the index page from the `tag_controller.ex` 
+because we are going to include it on a new LiveView for `Tags`.
+
+This is needed because of the sorting events of the table.
+
+So **remove** these next lines of code from the `lib/app_web/controllers/tag_controller.ex`
+```elixir
+def index(conn, _params) do
+  person_id = conn.assigns[:person][:id] || 0
+  tags = Tag.list_person_tags(person_id)
+
+  render(conn, "index.html",
+    tags: tags,
+    lists: App.List.get_lists_for_person(person_id),
+    custom_list: false
+  )
+end
+```
+
+Now, let's create the LiveView that will have the table for tags 
+and the redirections to all other pages on the `TagController`.
+
+Create a new file on `lib/app_web/live/tags_live.ex` with the following content.
+
+```elixir
+defmodule AppWeb.TagsLive do
+  use AppWeb, :live_view
+  alias App.{DateTimeHelper, Person, Tag, Repo}
+
+  # run authentication on mount
+  on_mount(AppWeb.AuthController)
+
+  @tags_topic "tags"
+
+  @impl true
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: AppWeb.Endpoint.subscribe(@tags_topic)
+
+    person_id = Person.get_person_id(socket.assigns)
+
+    tags = Tag.list_person_tags_complete(person_id)
+
+    {:ok,
+     assign(socket,
+       tags: tags,
+       lists: App.List.get_lists_for_person(person_id),
+       custom_list: false,
+       sort_column: :text,
+       sort_order: :asc
+     )}
+  end
+
+  @impl true
+  def handle_event("sort", %{"key" => key}, socket) do
+    sort_column =
+      key
+      |> String.to_atom()
+
+    sort_order =
+      if socket.assigns.sort_column == sort_column do
+        Repo.toggle_sort_order(socket.assigns.sort_order)
+      else
+        :asc
+      end
+
+    person_id = Person.get_person_id(socket.assigns)
+
+    tags = Tag.list_person_tags_complete(person_id, sort_column, sort_order)
+
+    {:noreply,
+     assign(socket,
+       tags: tags,
+       sort_column: sort_column,
+       sort_order: sort_order
+     )}
+  end
+
+  def format_date(date) do
+    DateTimeHelper.format_date(date)
+  end
+
+  def format_seconds(seconds) do
+    DateTimeHelper.format_duration(seconds)
+  end
+end
+```
+
+The whole code is similar to other LiveViews created on the project.
+
+**`mount`**
+
+This function is invoked when the LiveView component is mounted. It initializes the state of the LiveView.
+- `on_mount(AppWeb.AuthController)`: This line ensures that authentication is run when the LiveView component mounts.
+- The `if connected?(socket)` block subscribes to a topic (@tags_topic) if the user is connected, enabling real-time updates.
+- `person_id` is retrieved to identify the current user.
+- tags are fetched using `Tag.list_person_tags_complete(person_id)`, which retrieves all tags associated with the `person_id` and is the method that we created previously.
+- The socket is assigned various values, such as tags, lists, custom_list, sort_column, and sort_order, setting up the initial state of the LiveView.
+
+**`handle_event`**
+
+This function is called when a "sort" event is triggered by user interaction on the UI.
+- `sort_column` is set based on the event's key, determining which column to sort by.
+- `sort_order` is determined by the current state of sort_column and sort_order. If the sort_column is the same as the one already in the socket's assigns, the order is toggled using `Repo.toggle_sort_order`. Otherwise, it defaults to ascending (:asc).
+- Tags are then re-fetched with the new sort order and column, and the socket is updated with these new values.
+- This dynamic sorting mechanism allows the user interface to update the display order of tags based on user interaction.
+
+**`format_date(date)`**
+
+Uses DateTimeHelper.format_date to format a given date.
+
+**`format_seconds(seconds)`**
+
+Uses DateTimeHelper.format_duration to format a duration in seconds into a more human-readable format.
+
+### Creating the LiveView HTML template
+
+Create a new file on `lib/app_web/live/tags_live.html.heex` 
+that will handle the LiveView created in the previous section:
+
+```html
+<main class="font-sans container mx-auto">
+  <div class="relative overflow-x-auto mt-12">
+    <h1 class="mb-2 text-xl font-extrabold leading-none tracking-tight text-gray-900 md:text-5xl lg:text-6xl dark:text-white">
+      Listing Tags
+    </h1>
+
+    <.live_component
+      module={AppWeb.TableComponent}
+      id="tags_table_component"
+      rows={@tags}
+      sort_column={@sort_column}
+      sort_order={@sort_order}
+      highlight={fn _ -> false end}
+    >
+      <:column :let={tag} label="Name" key="text">
+        <td class="px-6 py-4 text-center" data-test-id={"text_#{tag.id}"}>
+          <%= tag.text %>
+        </td>
+      </:column>
+
+      <:column :let={tag} label="Color" key="color">
+        <td class="px-6 py-4 text-center" data-test-id={"color_#{tag.id}"}>
+          <span
+            style={"background-color:#{tag.color}"}
+            class="max-w-[144px] text-white font-bold py-1 px-2 rounded-full 
+            overflow-hidden text-ellipsis whitespace-nowrap inline-block"
+          >
+            <%= tag.color %>
+          </span>
+        </td>
+      </:column>
+
+      <:column :let={tag} label="Created At" key="inserted_at">
+        <td class="px-6 py-4 text-center" data-test-id={"inserted_at_#{tag.id}"}>
+          <%= format_date(tag.inserted_at) %>
+        </td>
+      </:column>
+
+      <:column :let={tag} label="Latest" key="last_used_at">
+        <td
+          class="px-6 py-4 text-center"
+          data-test-id={"last_used_at_#{tag.id}"}
+        >
+          <%= if tag.last_used_at do %>
+            <%= format_date(tag.last_used_at) %>
+          <% else %>
+            -
+          <% end %>
+        </td>
+      </:column>
+
+      <:column :let={tag} label="Items Count" key="items_count">
+        <td class="px-6 py-4 text-center" data-test-id={"items_count_#{tag.id}"}>
+          <a href={~p"/?filter_by_tag=#{tag.text}"} class="underline">
+            <%= tag.items_count %>
+          </a>
+        </td>
+      </:column>
+
+      <:column :let={tag} label="Total Time Logged" key="total_time_logged">
+        <td
+          class="px-6 py-4 text-center"
+          data-test-id={"total_time_logged_#{tag.id}"}
+        >
+          <%= format_seconds(tag.total_time_logged) %>
+        </td>
+      </:column>
+
+      <:column :let={tag} label="Actions" key="actions">
+        <td class="px-6 py-4 text-center" data-test-id={"actions_#{tag.id}"}>
+          <%= link("Edit", to: Routes.tag_path(@socket, :edit, tag)) %>
+
+          <span class="text-red-500 ml-10">
+            <%= link("Delete",
+              to: Routes.tag_path(@socket, :delete, tag),
+              method: :delete,
+              data: [confirm: "Are you sure you want to delete this tag?"]
+            ) %>
+          </span>
+        </td>
+      </:column>
+    </.live_component>
+
+    <.button
+      link_type="a"
+      to={Routes.tag_path(@socket, :new)}
+      label="Create Tag"
+      class="text-2xl text-center float-left rounded-md bg-green-600 hover:bg-green-700 
+      my-2 mt-2 ml-2 px-4 py-2 font-semibold text-white shadow-sm"
+    />
+  </div>
+</main>
+```
+
+The structure is similar to the `stats_live.html.heex` 
+with the new columns for tags and the events for sorting. 
+And it's using the `TableComponent` as well.
+
+## Adding the new page to the router
+
+Open the `lib/app_web/router.ex` and change the following line:
+
+```elixir
+...
+
+ scope "/", AppWeb do
+  pipe_through [:browser, :authOptional]
+  live "/", AppLive
+  resources "/lists", ListController, except: [:show]
+  get "/logout", AuthController, :logout
+  live "/stats", StatsLive
++  live "/tags", TagsLive
+  resources "/tags", TagController, except: [:show]
+end
+
+...
+```
+
+After that, you can remove the `lib/app_web/templates/tag/index.html.heex` file, 
+since we will use the `Tags` LiveView for the tags page now.
+
+Done! The Tags Page has the new columns and everything to be enhanced, congratulations!
+
+It's just missing tests, let's add them:
+
+`test/app/repo_test.exs`
+```elixir
+defmodule App.RepoTest do
+  use ExUnit.Case
+  alias App.Repo
+
+  describe "toggle_sort_order/1" do
+    test "toggles :asc to :desc" do
+      assert Repo.toggle_sort_order(:asc) == :desc
+    end
+
+    test "toggles :desc to :asc" do
+      assert Repo.toggle_sort_order(:desc) == :asc
+    end
+  end
+end
+```
+
+Add new test cases to the `test/app/tag_test.exs`
+
+```elixir
+describe "list_person_tags/1" do
+  test "returns an empty list for a person with no tags" do
+    assert [] == Tag.list_person_tags(-1)
+  end
+
+  test "returns a single tag for a person with one tag" do
+    tag = add_test_tag(%{text: "TestTag", person_id: 1, color: "#FCA5A5"})
+    assert [tag] == Tag.list_person_tags(1)
+  end
+
+  test "returns tags in alphabetical order for a person with multiple tags" do
+    add_test_tag(%{text: "BTag", person_id: 2, color: "#FCA5A5"})
+    add_test_tag(%{text: "ATag", person_id: 2, color: "#FCA5A5"})
+
+    tags = Tag.list_person_tags(2)
+    assert length(tags) == 2
+    assert tags |> Enum.map(& &1.text) == ["ATag", "BTag"]
+  end
+end
+
+describe "list_person_tags_complete/3" do
+  test "returns detailed tag information for a given person" do
+    add_test_tag_with_details(%{person_id: 3, text: "DetailedTag", color: "#FCA5A5"})
+
+    tags = Tag.list_person_tags_complete(3)
+    assert length(tags) > 0
+    assert tags |> Enum.all?(&is_map(&1))
+    assert tags |> Enum.all?(&Map.has_key?(&1, :last_used_at))
+    assert tags |> Enum.all?(&Map.has_key?(&1, :items_count))
+    assert tags |> Enum.all?(&Map.has_key?(&1, :total_time_logged))
+  end
+
+  test "sorts tags based on specified sort_column and sort_order" do
+    add_test_tag_with_details(%{person_id: 4, text: "CTag", color: "#FCA5A5"})
+    add_test_tag_with_details(%{person_id: 4, text: "ATag", color: "#FCA5A5"})
+    add_test_tag_with_details(%{person_id: 4, text: "BTag", color: "#FCA5A5"})
+
+    tags = Tag.list_person_tags_complete(4, :text, :asc)
+    assert tags |> Enum.map(& &1.text) == ["ATag", "BTag", "CTag"]
+  end
+
+  test "sorts tags with desc sort_order" do
+    add_test_tag_with_details(%{person_id: 4, text: "CTag", color: "#FCA5A5"})
+    add_test_tag_with_details(%{person_id: 4, text: "ATag", color: "#FCA5A5"})
+    add_test_tag_with_details(%{person_id: 4, text: "BTag", color: "#FCA5A5"})
+
+    tags = Tag.list_person_tags_complete(4, :text, :desc)
+    assert tags |> Enum.map(& &1.text) == ["CTag", "BTag", "ATag"]
+  end
+
+  test "uses default sort_order when none are provided" do
+    add_test_tag_with_details(%{person_id: 5, text: "SingleTag", color: "#FCA5A5"})
+
+    tags = Tag.list_person_tags_complete(5, :text)
+    assert length(tags) == 1
+  end
+
+  test "uses default parameters when none are provided" do
+    add_test_tag_with_details(%{person_id: 5, text: "SingleTag", color: "#FCA5A5"})
+
+    tags = Tag.list_person_tags_complete(5)
+    assert length(tags) == 1
+  end
+
+  test "handles invalid column" do
+    add_test_tag_with_details(%{person_id: 6, text: "BTag", color: "#FCA5A5"})
+    add_test_tag_with_details(%{person_id: 6, text: "AnotherTag", color: "#FCA5A5"})
+
+    tags = Tag.list_person_tags_complete(6, :invalid_column)
+    assert length(tags) == 2
+    assert tags |> Enum.map(& &1.text) == ["AnotherTag", "BTag"]
+  end
+end
+
+defp add_test_tag(attrs) do
+  {:ok, tag} = Tag.create_tag(attrs)
+  tag
+end
+
+defp add_test_tag_with_details(attrs) do
+  tag = add_test_tag(attrs)
+
+  {:ok, %{model: item}} = Item.create_item(%{
+    person_id: tag.person_id,
+    status: 0,
+    text: "some item",
+    tags: [tag]
+  })
+
+  seconds_ago_date = NaiveDateTime.new(Date.utc_today(), Time.add(Time.utc_now(), -10))
+  Timer.start(%{item_id: item.id, person_id: tag.person_id, start: seconds_ago_date})
+  Timer.stop_timer_for_item_id(item.id)
+
+  tag
+end
+```
+
+**Remove** these next lines from the `tag_controller_test.exs` since we don't have this page anymore:
+```elixir
+describe "index" do
+  test "lists all tags", %{conn: conn} do
+    conn = get(conn, Routes.tag_path(conn, :index))
+    assert html_response(conn, 200) =~ "Listing Tags"
+  end
+
+  test "lists all tags and display logout button", %{conn: conn} do
+    conn =
+      conn
+      |> assign(:jwt, AuthPlug.Token.generate_jwt!(%{id: 1, picture: ""}))
+      |> get(Routes.tag_path(conn, :index))
+
+    assert html_response(conn, 200) =~ "logout"
+  end
+end
+```
+
+`test/app_web/live/tags_live_test.exs`
+
+```elixir
+defmodule AppWeb.TagsLiveTest do
+  use AppWeb.ConnCase, async: true
+  alias App.{Item, Timer, Tag}
+  import Phoenix.LiveViewTest
+
+  @person_id 0
+
+  test "disconnected and connected render", %{conn: conn} do
+    {:ok, page_live, disconnected_html} = live(conn, "/tags")
+    assert disconnected_html =~ "Tags"
+    assert render(page_live) =~ "Tags"
+  end
+
+  test "display tags on table", %{conn: conn} do
+    tag1 = add_test_tag_with_details(%{person_id: @person_id, text: "Tag1", color: "#000000"})
+    tag2 = add_test_tag_with_details(%{person_id: @person_id, text: "Tag2", color: "#000000"})
+    tag3 = add_test_tag_with_details(%{person_id: @person_id, text: "Tag3", color: "#000000"})
+
+    {:ok, page_live, _html} = live(conn, "/tags")
+
+    assert render(page_live) =~ "Tags"
+
+    assert page_live
+           |> element("td[data-test-id=text_#{tag1.id}")
+           |> render() =~
+             "Tag1"
+
+    assert page_live
+           |> element("td[data-test-id=text_#{tag2.id}")
+           |> render() =~
+             "Tag2"
+
+    assert page_live
+           |> element("td[data-test-id=text_#{tag3.id}")
+           |> render() =~
+             "Tag3"
+  end
+
+  @tag tags: true
+  test "sorting column when clicked", %{conn: conn} do
+    add_test_tag_with_details(%{person_id: @person_id, text: "a", color: "#000000"})
+    add_test_tag_with_details(%{person_id: @person_id, text: "z", color: "#000000"})
+
+    {:ok, page_live, _html} = live(conn, "/tags")
+
+    # sort first time
+    result =
+      page_live |> element("th[phx-value-key=text]") |> render_click()
+
+    [first_element | _] = Floki.find(result, "td[data-test-id^=text_]")
+    assert first_element |> Floki.text() =~ "z"
+
+    # sort second time
+    result =
+      page_live |> element("th[phx-value-key=text]") |> render_click()
+
+    [first_element | _] = Floki.find(result, "td[data-test-id^=text_]")
+
+    assert first_element |> Floki.text() =~ "a"
+  end
+
+  defp add_test_tag_with_details(attrs) do
+    {:ok, tag} = Tag.create_tag(attrs)
+
+    {:ok, %{model: item}} = Item.create_item(%{
+      person_id: tag.person_id,
+      status: 0,
+      text: "some item",
+      tags: [tag]
+    })
+
+    seconds_ago_date = NaiveDateTime.new(Date.utc_today(), Time.add(Time.utc_now(), -10))
+    Timer.start(%{item_id: item.id, person_id: tag.person_id, start: seconds_ago_date})
+    Timer.stop_timer_for_item_id(item.id)
+
+    tag
+  end
+end
+```
+
+After these tests, you are ready to run the application and see your new changes!
+
+# 16. `People` in Different Timezones 🌐
 
 Our application works not only for ourselves
 but in a *collaborative environment*. 
@@ -5445,7 +6023,7 @@ the value of the `Datetime` of the `timer`
 *wouldn't make sense to you*.
 
 
-## 15.1 Getting the `person`'s Timezone
+## 16.1 Getting the `person`'s Timezone
 
 The easiest way to solve this is
 to only change how the `timers` are displayed
@@ -5525,7 +6103,7 @@ But before that,
 let's adjust how it is *displayed to the person*.
 
 
-## 15.2 Changing how the timer datetime is displayed
+## 16.2 Changing how the timer datetime is displayed
 
 Open `lib/app_web/live/app_live.html.heex`
 and locate the line
@@ -5574,7 +6152,7 @@ please check
 [`lib/app_web/live/app_live.html.heex`](https://github.com/dwyl/mvp/blob/63d98958be8f858e6ebcd063fa022bb59964b612/lib/app_web/live/app_live.html.heex#L326-L341).
 
 
-## 15.3 Persisting the adjusted timezone
+## 16.3 Persisting the adjusted timezone
 
 Now that we are displaying the correct timezones,
 we need to make sure the adjusted updated timer
@@ -5705,7 +6283,7 @@ please check
 [`lib/app_web/live/app_live.ex`](https://github.com/dwyl/mvp/blob/63d98958be8f858e6ebcd063fa022bb59964b612/lib/app_web/live/app_live.ex#L218).
 
 
-## 15.4 Adding test
+## 16.4 Adding test
 
 Let's add a test case that will check if the datetime 
 is shown with an offset that is mocked during testing.
@@ -5803,7 +6381,7 @@ we expect the persisted value to be
 one hour *less* than what the person inputted. 
 
 
-# 16. `Lists`
+# 17. `Lists`
 
 In preparation for the next set of features in the `MVP`,
 we added `lists`
@@ -5823,7 +6401,7 @@ please comment on the issue:
 
 
 
-# 17. Reordering `items` Using Drag & Drop
+# 18. Reordering `items` Using Drag & Drop
 
 At present `people` using the `App`
 can only add new `items` to a stack
@@ -5848,11 +6426,11 @@ please see:
 
 
 
-# 18. Run the _Finished_ MVP App!
+# 19. Run the _Finished_ MVP App!
 
 With all the code saved, let's run the tests one more time.
 
-## 18.1 Run the Tests
+## 19.1 Run the Tests
 
 In your terminal window, run: 
 
@@ -5895,7 +6473,7 @@ COV    FILE                                        LINES RELEVANT   MISSED
 All tests pass and we have **`100%` Test Coverage**.
 This reminds us just how few _relevant_ lines of code there are in the MVP!
 
-## 18.2 Run The App
+## 19.2 Run The App
 
 In your second terminal tab/window, run:
 

--- a/lib/app/repo.ex
+++ b/lib/app/repo.ex
@@ -3,38 +3,6 @@ defmodule App.Repo do
     otp_app: :app,
     adapter: Ecto.Adapters.Postgres
 
-  @doc """
-  `validate_order/1` validates the ordering is one of `asc` or `desc`
-
-  ## Examples
-
-      iex> App.Repo.validate_order("asc")
-      true
-
-      iex> App.Repo.validate_order(:asc)
-      true
-
-      iex> App.Repo.validate_order(:invalid)
-      false
-
-      # Avoid common SQL injection attacks:
-      iex> App.Repo.validate_order("OR 1=1")
-      false
-  """
-  def validate_order(order) when is_bitstring(order) do
-    Enum.member?(
-      ~w(asc desc),
-      order
-    )
-  end
-
-  def validate_order(order) when is_atom(order) do
-    Enum.member?(
-      [:asc, :desc],
-      order
-    )
-  end
-
   def toggle_sort_order(:asc), do: :desc
   def toggle_sort_order(:desc), do: :asc
 end

--- a/lib/app/repo.ex
+++ b/lib/app/repo.ex
@@ -2,4 +2,39 @@ defmodule App.Repo do
   use Ecto.Repo,
     otp_app: :app,
     adapter: Ecto.Adapters.Postgres
+
+  @doc """
+  `validate_order/1` validates the ordering is one of `asc` or `desc`
+
+  ## Examples
+
+      iex> App.Repo.validate_order("asc")
+      true
+
+      iex> App.Repo.validate_order(:asc)
+      true
+
+      iex> App.Repo.validate_order(:invalid)
+      false
+
+      # Avoid common SQL injection attacks:
+      iex> App.Repo.validate_order("OR 1=1")
+      false
+  """
+  def validate_order(order) when is_bitstring(order) do
+    Enum.member?(
+      ~w(asc desc),
+      order
+    )
+  end
+
+  def validate_order(order) when is_atom(order) do
+    Enum.member?(
+      [:asc, :desc],
+      order
+    )
+  end
+
+  def toggle_sort_order(:asc), do: :desc
+  def toggle_sort_order(:desc), do: :asc
 end

--- a/lib/app/stats.ex
+++ b/lib/app/stats.ex
@@ -31,7 +31,7 @@ defmodule App.Stats do
     sort_column =
       if validate_sort_column(sort_column), do: sort_column, else: "person_id"
 
-    sort_order = if validate_order(sort_order), do: sort_order, else: "asc"
+    sort_order = if Repo.validate_order(sort_order), do: sort_order, else: "asc"
 
     sql = """
     SELECT i.person_id,
@@ -86,28 +86,6 @@ defmodule App.Stats do
     Enum.member?(
       ~w(person_id num_items num_timers first_inserted_at last_inserted_at total_timers_in_seconds),
       column
-    )
-  end
-
-  @doc """
-  `validate_order/1` validates the ordering is one of `asc` or `desc`
-
-  ## Examples
-
-      iex> App.Stats.validate_order("asc")
-      true
-
-      iex> App.Stats.validate_order(:invalid)
-      false
-
-      # Avoid common SQL injection attacks:
-      iex> App.Stats.validate_order("OR 1=1")
-      false
-  """
-  def validate_order(order) do
-    Enum.member?(
-      ~w(asc desc),
-      order
     )
   end
 end

--- a/lib/app/stats.ex
+++ b/lib/app/stats.ex
@@ -26,12 +26,9 @@ defmodule App.Stats do
         sort_order \\ :asc
       ) do
     sort_column = to_string(sort_column)
-    sort_order = to_string(sort_order)
 
     sort_column =
       if validate_sort_column(sort_column), do: sort_column, else: "person_id"
-
-    sort_order = if Repo.validate_order(sort_order), do: sort_order, else: "asc"
 
     sql = """
     SELECT i.person_id,
@@ -43,7 +40,7 @@ defmodule App.Stats do
     FROM items i
     LEFT JOIN timers t ON t.item_id = i.id
     GROUP BY i.person_id
-    ORDER BY #{sort_column} #{sort_order}
+    ORDER BY #{sort_column} #{to_string(sort_order)}
     """
 
     Ecto.Adapters.SQL.query!(Repo, sql)

--- a/lib/app/tag.ex
+++ b/lib/app/tag.ex
@@ -100,8 +100,6 @@ defmodule App.Tag do
     sort_column =
       if validate_sort_column(sort_column), do: sort_column, else: :text
 
-    sort_order = if Repo.validate_order(sort_order), do: sort_order, else: :asc
-
     Tag
     |> where(person_id: ^person_id)
     |> join(:left, [t], it in ItemTag, on: t.id == it.tag_id)

--- a/lib/app/tag.ex
+++ b/lib/app/tag.ex
@@ -12,6 +12,7 @@ defmodule App.Tag do
     field :text, :string
 
     field :last_used_at, :naive_datetime, virtual: true
+    field :items_count, :integer, virtual: true
 
     many_to_many(:items, Item, join_through: ItemTag)
     timestamps()
@@ -95,7 +96,11 @@ defmodule App.Tag do
     |> where(person_id: ^person_id)
     |> join(:left, [t], it in ItemTag, on: t.id == it.tag_id)
     |> group_by([t], t.id)
-    |> select([t, it], %{t | last_used_at: max(it.inserted_at)})
+    |> select([t, it], %{
+      t
+      | last_used_at: max(it.inserted_at),
+        items_count: count(it.tag_id)
+    })
     |> order_by([t], t.text)
     |> Repo.all()
   end

--- a/lib/app/tag.ex
+++ b/lib/app/tag.ex
@@ -96,12 +96,13 @@ defmodule App.Tag do
     Tag
     |> where(person_id: ^person_id)
     |> join(:left, [t], it in ItemTag, on: t.id == it.tag_id)
-    |> join(:left, [t, it], tm in Timer, on: tm.item_id == it.item_id)
+    |> join(:left, [t, it], i in Item, on: i.id == it.item_id)
+    |> join(:left, [t, it, i], tm in Timer, on: tm.item_id == i.id)
     |> group_by([t], t.id)
-    |> select([t, it, tm], %{
+    |> select([t, it, i, tm], %{
       t
       | last_used_at: max(it.inserted_at),
-        items_count: count(it.tag_id),
+        items_count: fragment("count(DISTINCT ?)", i.id),
         total_time_logged:
           sum(
             coalesce(

--- a/lib/app/tag.ex
+++ b/lib/app/tag.ex
@@ -11,6 +11,8 @@ defmodule App.Tag do
     field :person_id, :integer
     field :text, :string
 
+    field :last_used_at, :naive_datetime, virtual: true
+
     many_to_many(:items, Item, join_through: ItemTag)
     timestamps()
   end
@@ -85,6 +87,16 @@ defmodule App.Tag do
     Tag
     |> where(person_id: ^person_id)
     |> order_by(:text)
+    |> Repo.all()
+  end
+
+  def list_person_tags_complete(person_id) do
+    Tag
+    |> where(person_id: ^person_id)
+    |> join(:left, [t], it in ItemTag, on: t.id == it.tag_id)
+    |> group_by([t], t.id)
+    |> select([t, it], %{t | last_used_at: max(it.inserted_at)})
+    |> order_by([t], t.text)
     |> Repo.all()
   end
 

--- a/lib/app/tag.ex
+++ b/lib/app/tag.ex
@@ -92,7 +92,16 @@ defmodule App.Tag do
     |> Repo.all()
   end
 
-  def list_person_tags_complete(person_id) do
+  def list_person_tags_complete(
+        person_id,
+        sort_column \\ :text,
+        sort_order \\ :asc
+      ) do
+    sort_column =
+      if validate_sort_column(sort_column), do: sort_column, else: :text
+
+    sort_order = if Repo.validate_order(sort_order), do: sort_order, else: :asc
+
     Tag
     |> where(person_id: ^person_id)
     |> join(:left, [t], it in ItemTag, on: t.id == it.tag_id)
@@ -115,7 +124,7 @@ defmodule App.Tag do
             )
           )
     })
-    |> order_by([t], t.text)
+    |> order_by(^get_order_by_keyword(sort_column, sort_order))
     |> Repo.all()
   end
 
@@ -135,5 +144,27 @@ defmodule App.Tag do
 
   def delete_tag(%Tag{} = tag) do
     Repo.delete(tag)
+  end
+
+  defp validate_sort_column(column) do
+    Enum.member?(
+      [
+        :text,
+        :color,
+        :created_at,
+        :last_used_at,
+        :items_count,
+        :total_time_logged
+      ],
+      column
+    )
+  end
+
+  defp get_order_by_keyword(sort_column, :asc) do
+    [asc: sort_column]
+  end
+
+  defp get_order_by_keyword(sort_column, :desc) do
+    [desc: sort_column]
   end
 end

--- a/lib/app_web/controllers/tag_controller.ex
+++ b/lib/app_web/controllers/tag_controller.ex
@@ -3,17 +3,6 @@ defmodule AppWeb.TagController do
   alias App.{Person, Tag}
   plug :permission_tag when action in [:edit, :update, :delete]
 
-  def index(conn, _params) do
-    person_id = conn.assigns[:person][:id] || 0
-    tags = Tag.list_person_tags(person_id)
-
-    render(conn, "index.html",
-      tags: tags,
-      lists: App.List.get_lists_for_person(person_id),
-      custom_list: false
-    )
-  end
-
   def new(conn, _params) do
     changeset = Tag.changeset(%Tag{})
     render(conn, "new.html", changeset: changeset)

--- a/lib/app_web/live/stats_live.ex
+++ b/lib/app_web/live/stats_live.ex
@@ -1,7 +1,7 @@
 defmodule AppWeb.StatsLive do
   require Logger
   use AppWeb, :live_view
-  alias App.{Stats, DateTimeHelper, Person}
+  alias App.{Stats, DateTimeHelper, Person, Repo}
   alias Phoenix.Socket.Broadcast
 
   # run authentication on mount
@@ -74,7 +74,7 @@ defmodule AppWeb.StatsLive do
 
     sort_order =
       if socket.assigns.sort_column == sort_column do
-        toggle_sort_order(socket.assigns.sort_order)
+        Repo.toggle_sort_order(socket.assigns.sort_order)
       else
         :asc
       end
@@ -114,7 +114,4 @@ defmodule AppWeb.StatsLive do
 
   def is_highlighted_person?(metric, person_id),
     do: metric.person_id == person_id
-
-  defp toggle_sort_order(:asc), do: :desc
-  defp toggle_sort_order(:desc), do: :asc
 end

--- a/lib/app_web/live/stats_live.html.heex
+++ b/lib/app_web/live/stats_live.html.heex
@@ -13,7 +13,7 @@
       highlight={&is_highlighted_person?(&1, @person_id)}
     >
       <:column :let={metric} label="Id" key="person_id">
-        <td class="px-6 py-4" data-test-id="person_id">
+        <td class="px-6 py-4" data-test-id={"person_id_#{metric.person_id}"}>
           <a href={person_link(metric.person_id)}>
             <%= metric.person_id %>
           </a>
@@ -21,25 +21,37 @@
       </:column>
 
       <:column :let={metric} label="Items" key="num_items">
-        <td class="px-6 py-4 text-center" data-test-id="num_items">
+        <td
+          class="px-6 py-4 text-center"
+          data-test-id={"num_items_#{metric.person_id}"}
+        >
           <%= metric.num_items %>
         </td>
       </:column>
 
       <:column :let={metric} label="Timers" key="num_timers">
-        <td class="px-6 py-4 text-center" data-test-id="num_timers">
+        <td
+          class="px-6 py-4 text-center"
+          data-test-id={"num_timers_#{metric.person_id}"}
+        >
           <%= metric.num_timers %>
         </td>
       </:column>
 
       <:column :let={metric} label="First Joined" key="first_inserted_at">
-        <td class="px-6 py-4 text-center" data-test-id="first_inserted_at">
+        <td
+          class="px-6 py-4 text-center"
+          data-test-id={"first_inserted_at_#{metric.person_id}"}
+        >
           <%= format_date(metric.first_inserted_at) %>
         </td>
       </:column>
 
       <:column :let={metric} label="Last Item Inserted" key="last_inserted_at">
-        <td class="px-6 py-4 text-center" data-test-id="last_inserted_at">
+        <td
+          class="px-6 py-4 text-center"
+          data-test-id={"last_inserted_at_#{metric.person_id}"}
+        >
           <%= format_date(metric.last_inserted_at) %>
         </td>
       </:column>
@@ -49,7 +61,10 @@
         label="Total Elapsed Time"
         key="total_timers_in_seconds"
       >
-        <td class="px-6 py-4 text-center" data-test-id="total_timers_in_seconds">
+        <td
+          class="px-6 py-4 text-center"
+          data-test-id={"total_timers_in_seconds_#{metric.person_id}"}
+        >
           <%= format_seconds(metric.total_timers_in_seconds) %>
         </td>
       </:column>

--- a/lib/app_web/live/tags_live.ex
+++ b/lib/app_web/live/tags_live.ex
@@ -19,7 +19,9 @@ defmodule AppWeb.TagsLive do
      assign(socket,
        tags: tags,
        lists: App.List.get_lists_for_person(person_id),
-       custom_list: false
+       custom_list: false,
+       sort_column: :text,
+       sort_order: :asc
      )}
   end
 

--- a/lib/app_web/live/tags_live.ex
+++ b/lib/app_web/live/tags_live.ex
@@ -28,4 +28,8 @@ defmodule AppWeb.TagsLive do
   def format_date(date) do
     DateTimeHelper.format_date(date)
   end
+
+  def format_seconds(seconds) do
+    DateTimeHelper.format_duration(seconds)
+  end
 end

--- a/lib/app_web/live/tags_live.ex
+++ b/lib/app_web/live/tags_live.ex
@@ -1,6 +1,6 @@
 defmodule AppWeb.TagsLive do
   use AppWeb, :live_view
-  alias App.{DateTimeHelper, Person, Tag}
+  alias App.{DateTimeHelper, Person, Tag, Repo}
 
   # run authentication on mount
   on_mount(AppWeb.AuthController)
@@ -22,6 +22,31 @@ defmodule AppWeb.TagsLive do
        custom_list: false,
        sort_column: :text,
        sort_order: :asc
+     )}
+  end
+
+  @impl true
+  def handle_event("sort", %{"key" => key}, socket) do
+    sort_column =
+      key
+      |> String.to_atom()
+
+    sort_order =
+      if socket.assigns.sort_column == sort_column do
+        Repo.toggle_sort_order(socket.assigns.sort_order)
+      else
+        :asc
+      end
+
+    person_id = Person.get_person_id(socket.assigns)
+
+    tags = Tag.list_person_tags_complete(person_id, sort_column, sort_order)
+
+    {:noreply,
+     assign(socket,
+       tags: tags,
+       sort_column: sort_column,
+       sort_order: sort_order
      )}
   end
 

--- a/lib/app_web/live/tags_live.ex
+++ b/lib/app_web/live/tags_live.ex
@@ -13,7 +13,7 @@ defmodule AppWeb.TagsLive do
 
     person_id = Person.get_person_id(socket.assigns)
 
-    tags = Tag.list_person_tags(person_id)
+    tags = Tag.list_person_tags_complete(person_id)
 
     {:ok,
      assign(socket,

--- a/lib/app_web/live/tags_live.ex
+++ b/lib/app_web/live/tags_live.ex
@@ -1,0 +1,29 @@
+defmodule AppWeb.TagsLive do
+  use AppWeb, :live_view
+  alias App.{DateTimeHelper, Person, Tag}
+
+  # run authentication on mount
+  on_mount(AppWeb.AuthController)
+
+  @tags_topic "tags"
+
+  @impl true
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: AppWeb.Endpoint.subscribe(@tags_topic)
+
+    person_id = Person.get_person_id(socket.assigns)
+
+    tags = Tag.list_person_tags(person_id)
+
+    {:ok,
+     assign(socket,
+       tags: tags,
+       lists: App.List.get_lists_for_person(person_id),
+       custom_list: false
+     )}
+  end
+
+  def format_date(date) do
+    DateTimeHelper.format_date(date)
+  end
+end

--- a/lib/app_web/live/tags_live.html.heex
+++ b/lib/app_web/live/tags_live.html.heex
@@ -44,7 +44,9 @@
 
       <:column :let={tag} label="Items Count" key="items_count">
         <td class="px-6 py-4 text-center" data-test-id="color">
-          <%= tag.items_count %>
+          <a href={~p"/?filter_by_tag=#{tag.text}"} class="underline">
+            <%= tag.items_count %>
+          </a>
         </td>
       </:column>
 

--- a/lib/app_web/live/tags_live.html.heex
+++ b/lib/app_web/live/tags_live.html.heex
@@ -9,13 +9,14 @@
       highlight={fn _ -> false end}
     >
       <:column :let={tag} label="Name" key="text">
-        <td class="px-6 py-4 text-center" data-test-id="text">
+        <td class="px-6 py-4 text-center" data-test-id={"text_#{tag.id}"}>
           <%= tag.text %>
         </td>
       </:column>
 
       <:column :let={tag} label="Color" key="color">
-        <td class="px-6 py-4 text-center" data-test-id="color">
+        <td class="px-6 py-4 text-center" data-test-id={"color_#{tag.id}"}>
+          ">
           <span
             style={"background-color:#{tag.color}"}
             class="max-w-[144px] text-white font-bold py-1 px-2 rounded-full 
@@ -27,13 +28,17 @@
       </:column>
 
       <:column :let={tag} label="Created At" key="inserted_at">
-        <td class="px-6 py-4 text-center" data-test-id="color">
-          <%= format_date(tag.inserted_at) %>
+        <td class="px-6 py-4 text-center" data-test-id={"inserted_at_#{tag.id}"}>
+          > <%= format_date(tag.inserted_at) %>
         </td>
       </:column>
 
       <:column :let={tag} label="Latest" key="last_used_at">
-        <td class="px-6 py-4 text-center" data-test-id="color">
+        <td
+          class="px-6 py-4 text-center"
+          data-test-id={"last_used_at_#{tag.id}"}
+        >
+          >
           <%= if tag.last_used_at do %>
             <%= format_date(tag.last_used_at) %>
           <% else %>
@@ -43,7 +48,8 @@
       </:column>
 
       <:column :let={tag} label="Items Count" key="items_count">
-        <td class="px-6 py-4 text-center" data-test-id="color">
+        <td class="px-6 py-4 text-center" data-test-id={"items_count_#{tag.id}"}>
+          >
           <a href={~p"/?filter_by_tag=#{tag.text}"} class="underline">
             <%= tag.items_count %>
           </a>
@@ -51,13 +57,16 @@
       </:column>
 
       <:column :let={tag} label="Total Time Logged" key="total_time_logged">
-        <td class="px-6 py-4 text-center" data-test-id="color">
-          <%= format_seconds(tag.total_time_logged) %>
+        <td
+          class="px-6 py-4 text-center"
+          data-test-id={"total_time_logged_#{tag.id}"}
+        >
+          > <%= format_seconds(tag.total_time_logged) %>
         </td>
       </:column>
 
       <:column :let={tag} label="Actions" key="actions">
-        <td class="px-6 py-4 text-center" data-test-id="actions">
+        <td class="px-6 py-4 text-center" data-test-id={"actions_#{tag.id}"}>
           <%= link("Edit", to: Routes.tag_path(@socket, :edit, tag)) %>
 
           <span class="text-red-500 ml-10">

--- a/lib/app_web/live/tags_live.html.heex
+++ b/lib/app_web/live/tags_live.html.heex
@@ -50,6 +50,12 @@
         </td>
       </:column>
 
+      <:column :let={tag} label="Total Time Logged" key="total_time_logged">
+        <td class="px-6 py-4 text-center" data-test-id="color">
+          <%= format_seconds(tag.total_time_logged) %>
+        </td>
+      </:column>
+
       <:column :let={tag} label="Actions" key="actions">
         <td class="px-6 py-4 text-center" data-test-id="actions">
           <%= link("Edit", to: Routes.tag_path(@socket, :edit, tag)) %>

--- a/lib/app_web/live/tags_live.html.heex
+++ b/lib/app_web/live/tags_live.html.heex
@@ -38,12 +38,12 @@
           </.td>
 
           <.td class="px-6 py-4 text-center">
-            <%= link("Edit", to: Routes.tag_path(@conn, :edit, tag)) %>
+            <%= link("Edit", to: Routes.tag_path(@socket, :edit, tag)) %>
           </.td>
 
           <.td class="px-6 py-4 text-center text-red-500">
             <%= link("Delete",
-              to: Routes.tag_path(@conn, :delete, tag),
+              to: Routes.tag_path(@socket, :delete, tag),
               method: :delete,
               data: [confirm: "Are you sure you want to delete this tag?"]
             ) %>
@@ -54,7 +54,7 @@
   </.table>
   <.button
     link_type="a"
-    to={Routes.tag_path(@conn, :new)}
+    to={Routes.tag_path(@socket, :new)}
     label="Create Tag"
     class="my-2"
   />

--- a/lib/app_web/live/tags_live.html.heex
+++ b/lib/app_web/live/tags_live.html.heex
@@ -32,9 +32,19 @@
         </td>
       </:column>
 
-      <:column :let={tag} label="Latest" key="tag_id">
+      <:column :let={tag} label="Latest" key="last_used_at">
         <td class="px-6 py-4 text-center" data-test-id="color">
-          <%= format_date(tag.last_used_at) %>
+          <%= if tag.last_used_at do %>
+            <%= format_date(tag.last_used_at) %>
+          <% else %>
+            -
+          <% end %>
+        </td>
+      </:column>
+
+      <:column :let={tag} label="Items Count" key="items_count">
+        <td class="px-6 py-4 text-center" data-test-id="color">
+          <%= tag.items_count %>
         </td>
       </:column>
 

--- a/lib/app_web/live/tags_live.html.heex
+++ b/lib/app_web/live/tags_live.html.heex
@@ -1,61 +1,57 @@
 <%= render(AppWeb.NavView, "nav.html", assigns) %>
 <.h2 class="text-center mt-3">Listing Tags</.h2>
+    <.live_component
+      module={AppWeb.TableComponent}
+      id="tags_table_component"
+      rows={@tags}
+      sort_column={@sort_column}
+      sort_order={@sort_order}
+      highlight={fn _ -> false end}
+    >
+      <:column :let={tag} label="Name" key="text">
+        <td class="px-6 py-4 text-center" data-test-id="text">
+          <%= tag.text %>
+        </td>
+      </:column>
 
-<.container class="font-sans container mx-auto">
-  <.table class="text-sm text-left text-gray-500 dark:text-gray-400 table-auto">
-    <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
-      <.tr>
-        <.th scope="col" class="px-6 py-3 text-center cursor-pointer">Name</.th>
-        <.th scope="col" class="px-6 py-3 text-center cursor-pointer">
-          Color
-        </.th>
-        <.th scope="col" class="px-6 py-3 text-center cursor-pointer">
-          Created At
-        </.th>
-
-        <.th class="w-3 text-center" colspan="2">Actions</.th>
-      </.tr>
-    </thead>
-    <tbody>
-      <%= for tag <- @tags do %>
-        <.tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
-          <.td class="px-6 py-4 text-center">
-            <%= tag.text %>
-          </.td>
-
-          <.td class="px-6 py-4 text-center">
-            <span
-              style={"background-color:#{tag.color}"}
-              class="max-w-[144px] text-white font-bold pyx-1 px-2 rounded-full 
+      <:column :let={tag} label="Color" key="color">
+        <td class="px-6 py-4 text-center" data-test-id="color">
+          <span
+            style={"background-color:#{tag.color}"}
+            class="max-w-[144px] text-white font-bold py-1 px-2 rounded-full 
             overflow-hidden text-ellipsis whitespace-nowrap inline-block"
-            >
-              <%= tag.color %>
-            </span>
-          </.td>
+          >
+            <%= tag.color %>
+          </span>
+        </td>
+      </:column>
 
-          <.td class="px-6 py-4 text-center">
-            <%= format_date(tag.inserted_at) %>
-          </.td>
+      <:column :let={tag} label="Created At" key="inserted_at">
+        <td class="px-6 py-4 text-center" data-test-id="color">
+          <%= format_date(tag.inserted_at) %>
+        </td>
+      </:column>
 
-          <.td class="px-6 py-4 text-center">
-            <%= link("Edit", to: Routes.tag_path(@socket, :edit, tag)) %>
-          </.td>
+      <:column :let={tag} label="Actions" key="actions">
+        <td class="px-6 py-4 text-center" data-test-id="actions">
+          <%= link("Edit", to: Routes.tag_path(@socket, :edit, tag)) %>
 
-          <.td class="px-6 py-4 text-center text-red-500">
+          <span class="text-red-500 ml-10">
             <%= link("Delete",
               to: Routes.tag_path(@socket, :delete, tag),
               method: :delete,
               data: [confirm: "Are you sure you want to delete this tag?"]
             ) %>
-          </.td>
-        </.tr>
-      <% end %>
-    </tbody>
-  </.table>
-  <.button
-    link_type="a"
-    to={Routes.tag_path(@socket, :new)}
-    label="Create Tag"
-    class="my-2"
-  />
-</.container>
+          </span>
+        </td>
+      </:column>
+    </.live_component>
+
+    <.button
+      link_type="a"
+      to={Routes.tag_path(@socket, :new)}
+      label="Create Tag"
+      class="my-2"
+    />
+  </div>
+</main>

--- a/lib/app_web/live/tags_live.html.heex
+++ b/lib/app_web/live/tags_live.html.heex
@@ -85,7 +85,8 @@
       link_type="a"
       to={Routes.tag_path(@socket, :new)}
       label="Create Tag"
-      class="my-2"
+      class="text-2xl text-center float-left rounded-md bg-green-600 hover:bg-green-700 
+      my-2 mt-2 ml-2 px-4 py-2 font-semibold text-white shadow-sm"
     />
   </div>
 </main>

--- a/lib/app_web/live/tags_live.html.heex
+++ b/lib/app_web/live/tags_live.html.heex
@@ -1,5 +1,9 @@
-<%= render(AppWeb.NavView, "nav.html", assigns) %>
-<.h2 class="text-center mt-3">Listing Tags</.h2>
+<main class="font-sans container mx-auto">
+  <div class="relative overflow-x-auto mt-12">
+    <h1 class="mb-2 text-xl font-extrabold leading-none tracking-tight text-gray-900 md:text-5xl lg:text-6xl dark:text-white">
+      Listing Tags
+    </h1>
+
     <.live_component
       module={AppWeb.TableComponent}
       id="tags_table_component"
@@ -16,7 +20,6 @@
 
       <:column :let={tag} label="Color" key="color">
         <td class="px-6 py-4 text-center" data-test-id={"color_#{tag.id}"}>
-          ">
           <span
             style={"background-color:#{tag.color}"}
             class="max-w-[144px] text-white font-bold py-1 px-2 rounded-full 
@@ -29,7 +32,7 @@
 
       <:column :let={tag} label="Created At" key="inserted_at">
         <td class="px-6 py-4 text-center" data-test-id={"inserted_at_#{tag.id}"}>
-          > <%= format_date(tag.inserted_at) %>
+          <%= format_date(tag.inserted_at) %>
         </td>
       </:column>
 
@@ -38,7 +41,6 @@
           class="px-6 py-4 text-center"
           data-test-id={"last_used_at_#{tag.id}"}
         >
-          >
           <%= if tag.last_used_at do %>
             <%= format_date(tag.last_used_at) %>
           <% else %>
@@ -49,7 +51,6 @@
 
       <:column :let={tag} label="Items Count" key="items_count">
         <td class="px-6 py-4 text-center" data-test-id={"items_count_#{tag.id}"}>
-          >
           <a href={~p"/?filter_by_tag=#{tag.text}"} class="underline">
             <%= tag.items_count %>
           </a>
@@ -61,7 +62,7 @@
           class="px-6 py-4 text-center"
           data-test-id={"total_time_logged_#{tag.id}"}
         >
-          > <%= format_seconds(tag.total_time_logged) %>
+          <%= format_seconds(tag.total_time_logged) %>
         </td>
       </:column>
 

--- a/lib/app_web/live/tags_live.html.heex
+++ b/lib/app_web/live/tags_live.html.heex
@@ -32,6 +32,12 @@
         </td>
       </:column>
 
+      <:column :let={tag} label="Latest" key="tag_id">
+        <td class="px-6 py-4 text-center" data-test-id="color">
+          <%= format_date(tag.last_used_at) %>
+        </td>
+      </:column>
+
       <:column :let={tag} label="Actions" key="actions">
         <td class="px-6 py-4 text-center" data-test-id="actions">
           <%= link("Edit", to: Routes.tag_path(@socket, :edit, tag)) %>

--- a/lib/app_web/router.ex
+++ b/lib/app_web/router.ex
@@ -32,6 +32,7 @@ defmodule AppWeb.Router do
     resources "/lists", ListController, except: [:show]
     get "/logout", AuthController, :logout
     live "/stats", StatsLive
+    live "/tags", TagsLive
     resources "/tags", TagController, except: [:show]
   end
 

--- a/lib/app_web/templates/tag/index.html.heex
+++ b/lib/app_web/templates/tag/index.html.heex
@@ -1,38 +1,56 @@
 <%= render(AppWeb.NavView, "nav.html", assigns) %>
 <.h2 class="text-center mt-3">Listing Tags</.h2>
 
-<.container>
-  <.table class="my-4">
-    <.tr>
-      <.th>Name</.th>
-
-      <.th class="w-3"></.th>
-      <.th class="w-3"></.th>
-    </.tr>
-    <%= for tag <- @tags do %>
+<.container class="font-sans container mx-auto">
+  <.table class="text-sm text-left text-gray-500 dark:text-gray-400 table-auto">
+    <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
       <.tr>
-        <.td>
-          <span
-            style={"background-color:#{tag.color}"}
-            class="max-w-[144px] text-white font-bold pyx-1 px-2 rounded-full 
-            overflow-hidden text-ellipsis whitespace-nowrap inline-block"
-          >
-            <%= tag.text %>
-          </span>
-        </.td>
+        <.th scope="col" class="px-6 py-3 text-center cursor-pointer">Name</.th>
+        <.th scope="col" class="px-6 py-3 text-center cursor-pointer">
+          Color
+        </.th>
+        <.th scope="col" class="px-6 py-3 text-center cursor-pointer">
+          Created At
+        </.th>
 
-        <.td>
-          <%= link("Edit", to: Routes.tag_path(@conn, :edit, tag)) %>
-        </.td>
-        <.td class="!text-red-500">
-          <%= link("Delete",
-            to: Routes.tag_path(@conn, :delete, tag),
-            method: :delete,
-            data: [confirm: "Are you sure you want to delete this tag?"]
-          ) %>
-        </.td>
+        <.th class="w-3 text-center" colspan="2">Actions</.th>
       </.tr>
-    <% end %>
+    </thead>
+    <tbody>
+      <%= for tag <- @tags do %>
+        <.tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
+          <.td class="px-6 py-4 text-center">
+            <%= tag.text %>
+          </.td>
+
+          <.td class="px-6 py-4 text-center">
+            <span
+              style={"background-color:#{tag.color}"}
+              class="max-w-[144px] text-white font-bold pyx-1 px-2 rounded-full 
+            overflow-hidden text-ellipsis whitespace-nowrap inline-block"
+            >
+              <%= tag.color %>
+            </span>
+          </.td>
+
+          <.td class="px-6 py-4 text-center">
+            <%= format_date(tag.inserted_at) %>
+          </.td>
+
+          <.td class="px-6 py-4 text-center">
+            <%= link("Edit", to: Routes.tag_path(@conn, :edit, tag)) %>
+          </.td>
+
+          <.td class="px-6 py-4 text-center text-red-500">
+            <%= link("Delete",
+              to: Routes.tag_path(@conn, :delete, tag),
+              method: :delete,
+              data: [confirm: "Are you sure you want to delete this tag?"]
+            ) %>
+          </.td>
+        </.tr>
+      <% end %>
+    </tbody>
   </.table>
   <.button
     link_type="a"

--- a/lib/app_web/views/tag_view.ex
+++ b/lib/app_web/views/tag_view.ex
@@ -1,3 +1,8 @@
 defmodule AppWeb.TagView do
   use AppWeb, :view
+  alias App.DateTimeHelper
+
+  def format_date(date) do
+    DateTimeHelper.format_date(date)
+  end
 end

--- a/lib/app_web/views/tag_view.ex
+++ b/lib/app_web/views/tag_view.ex
@@ -1,8 +1,3 @@
 defmodule AppWeb.TagView do
   use AppWeb, :view
-  alias App.DateTimeHelper
-
-  def format_date(date) do
-    DateTimeHelper.format_date(date)
-  end
 end

--- a/test/app/repo_test.exs
+++ b/test/app/repo_test.exs
@@ -2,27 +2,6 @@ defmodule App.RepoTest do
   use ExUnit.Case
   alias App.Repo
 
-  describe "validate_order/1" do
-    test "validates 'asc' and 'desc' as a valid string order" do
-      assert Repo.validate_order("asc") == true
-      assert Repo.validate_order("desc") == true
-    end
-
-    test "validates :asc and :desc as a valid atom order" do
-      assert Repo.validate_order(:asc) == true
-      assert Repo.validate_order(:desc) == true
-    end
-
-    test "rejects invalid string order" do
-      assert Repo.validate_order("invalid") == false
-      assert Repo.validate_order(:invalid) == false
-    end
-
-    test "rejects SQL injection attempt" do
-      assert Repo.validate_order("OR 1=1") == false
-    end
-  end
-
   describe "toggle_sort_order/1" do
     test "toggles :asc to :desc" do
       assert Repo.toggle_sort_order(:asc) == :desc

--- a/test/app/repo_test.exs
+++ b/test/app/repo_test.exs
@@ -1,0 +1,35 @@
+defmodule App.RepoTest do
+  use ExUnit.Case
+  alias App.Repo
+
+  describe "validate_order/1" do
+    test "validates 'asc' and 'desc' as a valid string order" do
+      assert Repo.validate_order("asc") == true
+      assert Repo.validate_order("desc") == true
+    end
+
+    test "validates :asc and :desc as a valid atom order" do
+      assert Repo.validate_order(:asc) == true
+      assert Repo.validate_order(:desc) == true
+    end
+
+    test "rejects invalid string order" do
+      assert Repo.validate_order("invalid") == false
+      assert Repo.validate_order(:invalid) == false
+    end
+
+    test "rejects SQL injection attempt" do
+      assert Repo.validate_order("OR 1=1") == false
+    end
+  end
+
+  describe "toggle_sort_order/1" do
+    test "toggles :asc to :desc" do
+      assert Repo.toggle_sort_order(:asc) == :desc
+    end
+
+    test "toggles :desc to :asc" do
+      assert Repo.toggle_sort_order(:desc) == :asc
+    end
+  end
+end

--- a/test/app/stats_test.exs
+++ b/test/app/stats_test.exs
@@ -84,7 +84,7 @@ defmodule App.StatsTest do
     refute Stats.validate_sort_column(:invalid)
   end
 
-  test "Stats.person_with_item_and_timer_count/1 returns a sorted list by person_id if invalid sorted column and order" do
+  test "Stats.person_with_item_and_timer_count/1 returns a sorted list by person_id if invalid sorted column" do
     {:ok, %{model: _, version: _version}} = Item.create_item(@valid_attrs)
     {:ok, %{model: _, version: _version}} = Item.create_item(@valid_attrs)
 
@@ -93,7 +93,7 @@ defmodule App.StatsTest do
 
     # list person with number of timers and items
     result =
-      Stats.person_with_item_and_timer_count(:invalid_column, :invalid_order)
+      Stats.person_with_item_and_timer_count(:invalid_column)
 
     assert length(result) == 3
 

--- a/test/app/tag_test.exs
+++ b/test/app/tag_test.exs
@@ -1,6 +1,6 @@
 defmodule App.TagTest do
   use App.DataCase, async: true
-  alias App.Tag
+  alias App.{Item, Tag, Timer}
 
   describe "Test constraints and requirements for Tag schema" do
     test "valid tag changeset" do
@@ -31,7 +31,7 @@ defmodule App.TagTest do
     @invalid_attrs %{text: nil}
 
     test "get_tag!/1 returns the tag with given id" do
-      {:ok, tag} = Tag.create_tag(@valid_attrs)
+      tag = add_test_tag(@valid_attrs)
       assert Tag.get_tag!(tag.id).text == tag.text
     end
 
@@ -55,7 +55,7 @@ defmodule App.TagTest do
     end
 
     test "delete tag" do
-      {:ok, tag} = Tag.create_tag(@valid_attrs)
+      tag = add_test_tag(@valid_attrs)
       assert {:ok, _etc} = Tag.delete_tag(tag)
     end
   end
@@ -64,10 +64,106 @@ defmodule App.TagTest do
     @valid_attrs %{text: "tag1", person_id: 1, color: "#FCA5A5"}
 
     test "list_person_tags_text/0 returns the tags texts" do
-      {:ok, _tag} = Tag.create_tag(@valid_attrs)
+      add_test_tag(@valid_attrs)
       tags_text_array = Tag.list_person_tags_text(@valid_attrs.person_id)
       assert length(tags_text_array) == 1
       assert Enum.at(tags_text_array, 0) == @valid_attrs.text
     end
+  end
+
+  describe "list_person_tags/1" do
+    test "returns an empty list for a person with no tags" do
+      assert [] == Tag.list_person_tags(-1)
+    end
+
+    test "returns a single tag for a person with one tag" do
+      tag = add_test_tag(%{text: "TestTag", person_id: 1, color: "#FCA5A5"})
+      assert [tag] == Tag.list_person_tags(1)
+    end
+
+    test "returns tags in alphabetical order for a person with multiple tags" do
+      add_test_tag(%{text: "BTag", person_id: 2, color: "#FCA5A5"})
+      add_test_tag(%{text: "ATag", person_id: 2, color: "#FCA5A5"})
+
+      tags = Tag.list_person_tags(2)
+      assert length(tags) == 2
+      assert tags |> Enum.map(& &1.text) == ["ATag", "BTag"]
+    end
+  end
+
+  describe "list_person_tags_complete/3" do
+    test "returns detailed tag information for a given person" do
+      add_test_tag_with_details(%{person_id: 3, text: "DetailedTag", color: "#FCA5A5"})
+
+      tags = Tag.list_person_tags_complete(3)
+      assert length(tags) > 0
+      assert tags |> Enum.all?(&is_map(&1))
+      assert tags |> Enum.all?(&Map.has_key?(&1, :last_used_at))
+      assert tags |> Enum.all?(&Map.has_key?(&1, :items_count))
+      assert tags |> Enum.all?(&Map.has_key?(&1, :total_time_logged))
+    end
+
+    test "sorts tags based on specified sort_column and sort_order" do
+      add_test_tag_with_details(%{person_id: 4, text: "CTag", color: "#FCA5A5"})
+      add_test_tag_with_details(%{person_id: 4, text: "ATag", color: "#FCA5A5"})
+      add_test_tag_with_details(%{person_id: 4, text: "BTag", color: "#FCA5A5"})
+
+      tags = Tag.list_person_tags_complete(4, :text, :asc)
+      assert tags |> Enum.map(& &1.text) == ["ATag", "BTag", "CTag"]
+    end
+
+    test "sorts tags with desc sort_order" do
+      add_test_tag_with_details(%{person_id: 4, text: "CTag", color: "#FCA5A5"})
+      add_test_tag_with_details(%{person_id: 4, text: "ATag", color: "#FCA5A5"})
+      add_test_tag_with_details(%{person_id: 4, text: "BTag", color: "#FCA5A5"})
+
+      tags = Tag.list_person_tags_complete(4, :text, :desc)
+      assert tags |> Enum.map(& &1.text) == ["CTag", "BTag", "ATag"]
+    end
+
+    test "uses default sort_order when none are provided" do
+      add_test_tag_with_details(%{person_id: 5, text: "SingleTag", color: "#FCA5A5"})
+
+      tags = Tag.list_person_tags_complete(5, :text)
+      assert length(tags) == 1
+    end
+
+    test "uses default parameters when none are provided" do
+      add_test_tag_with_details(%{person_id: 5, text: "SingleTag", color: "#FCA5A5"})
+
+      tags = Tag.list_person_tags_complete(5)
+      assert length(tags) == 1
+    end
+
+    test "handles invalid sort parameters" do
+      add_test_tag_with_details(%{person_id: 6, text: "BTag", color: "#FCA5A5"})
+      add_test_tag_with_details(%{person_id: 6, text: "AnotherTag", color: "#FCA5A5"})
+
+      tags = Tag.list_person_tags_complete(6, :invalid_column, :invalid_order)
+      assert length(tags) == 2
+      assert tags |> Enum.map(& &1.text) == ["AnotherTag", "BTag"]
+    end
+  end
+
+  defp add_test_tag(attrs) do
+    {:ok, tag} = Tag.create_tag(attrs)
+    tag
+  end
+
+  defp add_test_tag_with_details(attrs) do
+    tag = add_test_tag(attrs)
+
+    {:ok, %{model: item}} = Item.create_item(%{
+      person_id: tag.person_id,
+      status: 0,
+      text: "some item",
+      tags: [tag]
+    })
+
+    seconds_ago_date = NaiveDateTime.new(Date.utc_today(), Time.add(Time.utc_now(), -10))
+    Timer.start(%{item_id: item.id, person_id: tag.person_id, start: seconds_ago_date})
+    Timer.stop_timer_for_item_id(item.id)
+
+    tag
   end
 end

--- a/test/app/tag_test.exs
+++ b/test/app/tag_test.exs
@@ -135,11 +135,11 @@ defmodule App.TagTest do
       assert length(tags) == 1
     end
 
-    test "handles invalid sort parameters" do
+    test "handles invalid column" do
       add_test_tag_with_details(%{person_id: 6, text: "BTag", color: "#FCA5A5"})
       add_test_tag_with_details(%{person_id: 6, text: "AnotherTag", color: "#FCA5A5"})
 
-      tags = Tag.list_person_tags_complete(6, :invalid_column, :invalid_order)
+      tags = Tag.list_person_tags_complete(6, :invalid_column)
       assert length(tags) == 2
       assert tags |> Enum.map(& &1.text) == ["AnotherTag", "BTag"]
     end

--- a/test/app_web/controllers/tag_controller_test.exs
+++ b/test/app_web/controllers/tag_controller_test.exs
@@ -11,17 +11,6 @@ defmodule AppWeb.TagControllerTest do
     tag
   end
 
-  describe "new tag" do
-    test "renders form for creating a tag", %{conn: conn} do
-      conn =
-        conn
-        |> assign(:jwt, AuthPlug.Token.generate_jwt!(%{id: 1, picture: ""}))
-        |> get(Routes.tag_path(conn, :new))
-
-      assert html_response(conn, 200) =~ "New Tag"
-    end
-  end
-
   describe "create tag" do
     test "redirects to show when data is valid", %{conn: conn} do
       conn =
@@ -39,6 +28,17 @@ defmodule AppWeb.TagControllerTest do
         conn
         |> assign(:jwt, AuthPlug.Token.generate_jwt!(%{id: 1, picture: ""}))
         |> post(Routes.tag_path(conn, :create), tag: @invalid_attrs)
+
+      assert html_response(conn, 200) =~ "New Tag"
+    end
+  end
+
+  describe "new tag" do
+    test "renders form for creating a tag", %{conn: conn} do
+      conn =
+        conn
+        |> assign(:jwt, AuthPlug.Token.generate_jwt!(%{id: 1, picture: ""}))
+        |> get(Routes.tag_path(conn, :new))
 
       assert html_response(conn, 200) =~ "New Tag"
     end

--- a/test/app_web/controllers/tag_controller_test.exs
+++ b/test/app_web/controllers/tag_controller_test.exs
@@ -11,19 +11,14 @@ defmodule AppWeb.TagControllerTest do
     tag
   end
 
-  describe "index" do
-    test "lists all tags", %{conn: conn} do
-      conn = get(conn, Routes.tag_path(conn, :index))
-      assert html_response(conn, 200) =~ "Listing Tags"
-    end
-
-    test "lists all tags and display logout button", %{conn: conn} do
+  describe "new tag" do
+    test "renders form for creating a tag", %{conn: conn} do
       conn =
         conn
         |> assign(:jwt, AuthPlug.Token.generate_jwt!(%{id: 1, picture: ""}))
-        |> get(Routes.tag_path(conn, :index))
+        |> get(Routes.tag_path(conn, :new))
 
-      assert html_response(conn, 200) =~ "logout"
+      assert html_response(conn, 200) =~ "New Tag"
     end
   end
 

--- a/test/app_web/controllers/tag_controller_test.exs
+++ b/test/app_web/controllers/tag_controller_test.exs
@@ -44,17 +44,6 @@ defmodule AppWeb.TagControllerTest do
     end
   end
 
-  describe "new tag" do
-    test "renders form for creating a tag", %{conn: conn} do
-      conn =
-        conn
-        |> assign(:jwt, AuthPlug.Token.generate_jwt!(%{id: 1, picture: ""}))
-        |> get(Routes.tag_path(conn, :new))
-
-      assert html_response(conn, 200) =~ "New Tag"
-    end
-  end
-
   describe "edit tag" do
     setup [:create_tag]
 

--- a/test/app_web/live/stats_live_test.exs
+++ b/test/app_web/live/stats_live_test.exs
@@ -156,6 +156,5 @@ defmodule AppWeb.StatsLiveTest do
     [first_element | _] = Floki.find(result, "td[data-test-id=person_id_1]")
 
     assert first_element |> Floki.text() =~ "1"
-    first_element |> Floki.text() |> dbg()
   end
 end

--- a/test/app_web/live/stats_live_test.exs
+++ b/test/app_web/live/stats_live_test.exs
@@ -1,7 +1,7 @@
 defmodule AppWeb.StatsLiveTest do
   # alias App.DateTimeHelper
   use AppWeb.ConnCase, async: true
-  alias App.{Item, Timer}
+  alias App.{Item, Timer, DateTimeHelper}
   import Phoenix.LiveViewTest
 
   @person_id 55
@@ -32,27 +32,27 @@ defmodule AppWeb.StatsLiveTest do
     assert render(page_live) =~ "Stats"
 
     # two items and one timer expected
-    # assert page_live |> element("td[data-test-id=person_id]") |> render() =~
-    #          "55"
+    assert page_live |> element("td[data-test-id=person_id_55]") |> render() =~
+             "55"
 
-    # assert page_live |> element("td[data-test-id=num_items]") |> render() =~ "2"
+    assert page_live |> element("td[data-test-id=num_items_55]") |> render() =~ "2"
 
     assert page_live |> render() =~ "1"
 
-    # assert page_live
-    #        |> element("td[data-test-id=first_inserted_at]")
-    #        |> render() =~
-    #          DateTimeHelper.format_date(started)
+    assert page_live
+           |> element("td[data-test-id=first_inserted_at_55]")
+           |> render() =~
+             DateTimeHelper.format_date(started)
 
-    # assert page_live
-    #        |> element("td[data-test-id=last_inserted_at]")
-    #        |> render() =~
-    #          DateTimeHelper.format_date(started)
+    assert page_live
+           |> element("td[data-test-id=last_inserted_at_55]")
+           |> render() =~
+             DateTimeHelper.format_date(started)
 
-    # assert page_live
-    #        |> element("td[data-test-id=total_timers_in_seconds]")
-    #        |> render() =~
-    #          ""
+    assert page_live
+           |> element("td[data-test-id=total_timers_in_seconds_55]")
+           |> render() =~
+             ""
   end
 
   test "handle broadcast when item is created", %{conn: conn} do
@@ -63,8 +63,8 @@ defmodule AppWeb.StatsLiveTest do
     {:ok, page_live, _html} = live(conn, "/stats")
 
     assert render(page_live) =~ "Stats"
-    # num of items - this selector finds multiple items so this fails ...
-    # assert page_live |> element("td[data-test-id=num_items]") |> render() =~ "5"
+
+    assert page_live |> element("td[data-test-id=num_items_55]") |> render() =~ "5"
 
     # Creating another item.
     AppWeb.Endpoint.broadcast(
@@ -74,7 +74,7 @@ defmodule AppWeb.StatsLiveTest do
     )
 
     # num of items
-    # assert page_live |> element("td[data-test-id=num_items]") |> render() =~ "2"
+    assert page_live |> element("td[data-test-id=num_items_55]") |> render() =~ "2"
 
     # Broadcasting update. Shouldn't effect anything in the page
     AppWeb.Endpoint.broadcast(
@@ -84,7 +84,7 @@ defmodule AppWeb.StatsLiveTest do
     )
 
     # num of items
-    # assert page_live |> element("td[data-test-id=num_items]") |> render() =~ "2"
+    assert page_live |> element("td[data-test-id=num_items_55]") |> render() =~ "2"
   end
 
   test "handle broadcast when timer is created", %{conn: conn} do
@@ -95,9 +95,8 @@ defmodule AppWeb.StatsLiveTest do
     {:ok, page_live, _html} = live(conn, "/stats")
 
     assert render(page_live) =~ "Stats"
-    # num of timers - this selector returns multiple elements.
-    # assert page_live |> element("td[data-test-id=num_timers]") |> render() =~
-    #          "0"
+    assert page_live |> element("td[data-test-id=num_timers_55]") |> render() =~
+             "0"
 
     # Creating a timer.
     AppWeb.Endpoint.broadcast(
@@ -106,9 +105,8 @@ defmodule AppWeb.StatsLiveTest do
       {:create, payload: %{person_id: @person_id}}
     )
 
-    # num of timers - currently returning multiple elements ...
-    # assert page_live |> element("td[data-test-id=num_timers]") |> render() =~
-    #          "1"
+    assert page_live |> element("td[data-test-id=num_timers_55]") |> render() =~
+             "1"
 
     # Broadcasting update. Shouldn't effect anything in the page
     AppWeb.Endpoint.broadcast(
@@ -147,7 +145,7 @@ defmodule AppWeb.StatsLiveTest do
     result =
       page_live |> element("th[phx-value-key=person_id]") |> render_click()
 
-    [first_element | _] = Floki.find(result, "td[data-test-id=person_id]")
+    [first_element | _] = Floki.find(result, "td[data-test-id=person_id_2]")
 
     assert first_element |> Floki.text() =~ "2"
 
@@ -155,9 +153,9 @@ defmodule AppWeb.StatsLiveTest do
     result =
       page_live |> element("th[phx-value-key=person_id]") |> render_click()
 
-    [first_element | _] = Floki.find(result, "td[data-test-id=person_id]")
+    [first_element | _] = Floki.find(result, "td[data-test-id=person_id_1]")
 
-    # assert first_element |> Floki.text() =~ "1"
-    first_element |> Floki.text()
+    assert first_element |> Floki.text() =~ "1"
+    first_element |> Floki.text() |> dbg()
   end
 end

--- a/test/app_web/live/tags_live_test.exs
+++ b/test/app_web/live/tags_live_test.exs
@@ -1,0 +1,45 @@
+defmodule AppWeb.TagsLiveTest do
+  use AppWeb.ConnCase, async: true
+  alias App.{Item, Timer, Tag}
+  import Phoenix.LiveViewTest
+
+  @person_id 55
+
+  test "disconnected and connected render", %{conn: conn} do
+    {:ok, page_live, disconnected_html} = live(conn, "/tags")
+    assert disconnected_html =~ "Tags"
+    assert render(page_live) =~ "Tags"
+  end
+
+  # test "display tags on table", %{conn: conn} do
+  #   add_tag(%{person_id: @person_id, text: "Tag1", color: "#000000"})
+  #   add_tag(%{person_id: @person_id, text: "Tag2", color: "#000000"})
+  #   add_tag(%{person_id: @person_id, text: "Tag3", color: "#000000"})
+
+  #   {:ok, page_live, _html} = live(conn, "/tags")
+
+  #   assert render(page_live) =~ "Tags"
+
+  #   assert page_live
+  #          |> element("td[data-test-id=text_1]")
+  #          |> render() =~
+  #            "start!s"
+  # end
+
+  defp add_tag(attrs) do
+    {:ok, tag} = Tag.create_tag(attrs)
+
+    {:ok, %{model: item}} = Item.create_item(%{
+      person_id: @person_id,
+      status: 0,
+      text: "some item",
+      tags: [tag]
+    })
+
+    seconds_ago_date = NaiveDateTime.new(Date.utc_today(), Time.add(Time.utc_now(), -10))
+    Timer.start(%{item_id: item.id, person_id: @person_id, start: seconds_ago_date})
+    Timer.stop_timer_for_item_id(item.id)
+
+    tag
+  end
+end

--- a/test/app_web/live/tags_live_test.exs
+++ b/test/app_web/live/tags_live_test.exs
@@ -3,7 +3,7 @@ defmodule AppWeb.TagsLiveTest do
   alias App.{Item, Timer, Tag}
   import Phoenix.LiveViewTest
 
-  @person_id 55
+  @person_id 0
 
   test "disconnected and connected render", %{conn: conn} do
     {:ok, page_live, disconnected_html} = live(conn, "/tags")
@@ -11,33 +11,66 @@ defmodule AppWeb.TagsLiveTest do
     assert render(page_live) =~ "Tags"
   end
 
-  # test "display tags on table", %{conn: conn} do
-  #   tag1 = add_tag(%{person_id: @person_id, text: "Tag1", color: "#000000"})
-  #   add_tag(%{person_id: @person_id, text: "Tag2", color: "#000000"})
-  #   add_tag(%{person_id: @person_id, text: "Tag3", color: "#000000"})
+  test "display tags on table", %{conn: conn} do
+    tag1 = add_test_tag_with_details(%{person_id: @person_id, text: "Tag1", color: "#000000"})
+    tag2 = add_test_tag_with_details(%{person_id: @person_id, text: "Tag2", color: "#000000"})
+    tag3 = add_test_tag_with_details(%{person_id: @person_id, text: "Tag3", color: "#000000"})
 
-  #   {:ok, page_live, _html} = live(conn, "/tags")
+    {:ok, page_live, _html} = live(conn, "/tags")
 
-  #   assert render(page_live) =~ "Tags"
+    assert render(page_live) =~ "Tags"
 
-  #   assert page_live
-  #          |> element("td[data-test-id=text_#{tag1.id}")
-  #          |> render() =~
-  #            "Tag1"
-  # end
+    assert page_live
+           |> element("td[data-test-id=text_#{tag1.id}")
+           |> render() =~
+             "Tag1"
 
-  defp add_tag(attrs) do
+    assert page_live
+           |> element("td[data-test-id=text_#{tag2.id}")
+           |> render() =~
+             "Tag2"
+
+    assert page_live
+           |> element("td[data-test-id=text_#{tag3.id}")
+           |> render() =~
+             "Tag3"
+  end
+
+  @tag tags: true
+  test "sorting column when clicked", %{conn: conn} do
+    add_test_tag_with_details(%{person_id: @person_id, text: "a", color: "#000000"})
+    add_test_tag_with_details(%{person_id: @person_id, text: "z", color: "#000000"})
+
+    {:ok, page_live, _html} = live(conn, "/tags")
+
+    # sort first time
+    result =
+      page_live |> element("th[phx-value-key=text]") |> render_click()
+
+    [first_element | _] = Floki.find(result, "td[data-test-id^=text_]")
+    assert first_element |> Floki.text() =~ "z"
+
+    # sort second time
+    result =
+      page_live |> element("th[phx-value-key=text]") |> render_click()
+
+    [first_element | _] = Floki.find(result, "td[data-test-id^=text_]")
+
+    assert first_element |> Floki.text() =~ "a"
+  end
+
+  defp add_test_tag_with_details(attrs) do
     {:ok, tag} = Tag.create_tag(attrs)
 
     {:ok, %{model: item}} = Item.create_item(%{
-      person_id: @person_id,
+      person_id: tag.person_id,
       status: 0,
       text: "some item",
       tags: [tag]
     })
 
     seconds_ago_date = NaiveDateTime.new(Date.utc_today(), Time.add(Time.utc_now(), -10))
-    Timer.start(%{item_id: item.id, person_id: @person_id, start: seconds_ago_date})
+    Timer.start(%{item_id: item.id, person_id: tag.person_id, start: seconds_ago_date})
     Timer.stop_timer_for_item_id(item.id)
 
     tag

--- a/test/app_web/live/tags_live_test.exs
+++ b/test/app_web/live/tags_live_test.exs
@@ -12,7 +12,7 @@ defmodule AppWeb.TagsLiveTest do
   end
 
   # test "display tags on table", %{conn: conn} do
-  #   add_tag(%{person_id: @person_id, text: "Tag1", color: "#000000"})
+  #   tag1 = add_tag(%{person_id: @person_id, text: "Tag1", color: "#000000"})
   #   add_tag(%{person_id: @person_id, text: "Tag2", color: "#000000"})
   #   add_tag(%{person_id: @person_id, text: "Tag3", color: "#000000"})
 
@@ -21,9 +21,9 @@ defmodule AppWeb.TagsLiveTest do
   #   assert render(page_live) =~ "Tags"
 
   #   assert page_live
-  #          |> element("td[data-test-id=text_1]")
+  #          |> element("td[data-test-id=text_#{tag1.id}")
   #          |> render() =~
-  #            "start!s"
+  #            "Tag1"
   # end
 
   defp add_tag(attrs) do


### PR DESCRIPTION
This improves the Tags Page to have much more details on its table #396.

<img width="1170" alt="image" src="https://github.com/dwyl/mvp/assets/2154092/0f7fd3a7-109f-4612-a3e5-95fa61baa89f">

I moved some common methods between Stats <-> Tag to do the sorting on the Repo module, maybe we could create a new module for it, but let's see what you guys think.

# Things missing
- [x] Add tests for the new stuff
- Sorting the virtual columns https://github.com/dwyl/mvp/issues/436